### PR TITLE
Added -v

### DIFF
--- a/pip2/commands/_search.py
+++ b/pip2/commands/_search.py
@@ -6,6 +6,12 @@ def run(args):
     """
     Search indexes for packages that match args.package_name and display the results.
     An index can be specified using -i or --index-url followed by an address.
+    You can specify -v or --version followed by a specific version number and
+    search will return the closest match.
+    
+    In the future it will be changed to an expression so instead of returning a single
+    match, it will return multiple and you can use an expression like >0.6.3,!=0.8.3,<=1.0.2
+    to get all versions greater then 0.6.3 not 0.8.3 and all less then or equal to 1.0.2
     """
     
     #search returns a ReleasesList which is a list of ReleaseInfo's
@@ -25,13 +31,30 @@ def run(args):
     
     print("Recieved {0}".format(args))
     
-    #search!
-    releaseList = crawler.get_releases(args.package_name)
-    releaseList.sort_releases(reverse = False)
-    
-    #display the results!
     print("---------- Search Results ----------")
-    for release in releaseList:
+    #search!
+    if not args.version:
+        releaseList = crawler.get_releases(args.package_name)
+        releaseList.sort_releases(reverse = False)
+        
+        #display the results!
+        for release in releaseList:
+            print('\nName   : {0}'.format(release.name))
+            print('Version: {0}'.format(release.version))
+            dists = release.fetch_distributions()
+            print('Dists  : ')
+            i = 0
+            #print all distributions for one release
+            for key in dists.keys():
+                i += 1
+                print('{0}. {1}'.format(i, key))
+        print("\nSearch found {0} results".format(len(releaseList)))
+        
+    #use specified version expression 
+    else:
+        query = args.package_name + ' ==' + args.version
+        release = crawler.get_release(query)
+        
         print('\nName   : {0}'.format(release.name))
         print('Version: {0}'.format(release.version))
         dists = release.fetch_distributions()
@@ -41,6 +64,6 @@ def run(args):
         for key in dists.keys():
             i += 1
             print('{0}. {1}'.format(i, key))
-    print("\nSearch found {0} results".format(len(releaseList)))
+
         
     

--- a/pip2/pip_parser.py
+++ b/pip2/pip_parser.py
@@ -17,6 +17,7 @@ def create_parser():
     parser_search = subparsers.add_parser('search')
     parser_search.add_argument('package_name')
     parser_search.add_argument('-i', '--index-url', default=False)
+    parser_search.add_argument('-v', '--version', default=False)
     parser_search.set_defaults(func=pip2.commands.search)
 
     parser_freeze = subparsers.add_parser('freeze')


### PR DESCRIPTION
You can specify -v or --version followed by a specific version number and
search will return the closest match.

```
In the future it will be changed to an expression so instead of returning a single
match, it will return multiple and you can use an expression like >0.6.3,!=0.8.3,<=1.0.2
to get all versions greater then 0.6.3 not 0.8.3 and all less then or equal to 1.0.2
```
