### PR TITLE
Updated imports to be compatible with packaging.

### DIFF
--- a/pip2/__init__.py
+++ b/pip2/__init__.py
@@ -1,9 +1,9 @@
 __version__ = '0.0.1'
 
-import pip_parser
+import pip2.pip_parser 
 
 def main():
-    parser = pip_parser.create_parser()
+    parser = pip2.pip_parser.create_parser()
 
     args = parser.parse_args()
     args.func(args)

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -1,8 +1,8 @@
-import commands.install
+import pip2.commands.install
 import sys
 
 def install(args):
-    result = commands.install.install(args.package_list)
+    result = pip2.commands.install.install(args.package_list)
 
     if result['installed'] != []:
         successful = " ".join(map(str, result['installed']))

--- a/pip2/pip_parser.py
+++ b/pip2/pip_parser.py
@@ -1,5 +1,5 @@
 import argparse
-import cli_wrapper
+import pip2.cli_wrapper
 
 def create_parser():
     parser = argparse.ArgumentParser(prog='pip2')
@@ -7,6 +7,6 @@ def create_parser():
 
     parser_install = subparsers.add_parser('install')
     parser_install.add_argument('package_list', nargs='+')
-    parser_install.set_defaults(func=cli_wrapper.install)
+    parser_install.set_defaults(func=pip2.cli_wrapper.install)
     
     return parser


### PR DESCRIPTION
The imports currently only worked if you were in the correct directory. Now they should work when pip2 is packaged up and when running tests.
