### PR TITLE
Tdd, added a bunch of stuff!

### DIFF
--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -16,17 +16,20 @@ def install(args):
     return
 
 def freeze(args):
-    distributions = pip2.commands.freeze.freeze()
+    distributions = pip2.commands.freeze.freeze(args.version)
     
-    for dis in distributions:
-        print(dis)
+    for dist_name in distributions.keys():
+        if args.version:
+            print('{0:<30}{1}'.format(dist_name[:30], distributions[dist_name]['version']))
+        else:
+            print(dist_name)
         
     return
 
 def search(args):
     results, matches = pip2.commands.search.search(args.package)
     terminal_width = getTerminalSize()[0]
-    print(terminal_width)
+    
     name_len = 26 #package name alotted this many characters
     # package summary alotted this many characters per line, - 4 is for the ' - ' and 
     # leaving one extra space at end

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -1,7 +1,7 @@
 import pip2.commands.install
 import pip2.commands.freeze
 import pip2.commands.search
-import sys
+import sys, os
 
 def install(args):
     result = pip2.commands.install.install(args.package_list)
@@ -25,16 +25,32 @@ def freeze(args):
 
 def search(args):
     results, matches = pip2.commands.search.search(args.package)
+    terminal_width = 80 #get actual terminal width somehow?
+    name_len = 26 #package name alotted this many characters
+    # package summary alotted this many characters per line, - 4 is for the ' - ' and 
+    # leaving one extra space at end
+    sum_len = terminal_width - name_len - 4 # 50
     
     #for each search result
     for res_key in results.keys():
-        #print the package name and summary
-        print("{0} - {1}".format(res_key, results[res_key]))
+        # how much of the summary we have printed
+        printed = 0
+        #get as much as can fit on the first line
+        summary = results[res_key][:sum_len]
+        result = "{0:<{2}} - {1}".format(res_key[:name_len], summary, name_len)
+        print(result)
+        printed += sum_len
+        # while we haven't printed all of the summary
+        while(printed) < (len(results[res_key])):
+            # +3 is to compensate for ' - '
+            result = " "*(name_len+3) + results[res_key][printed:(printed+sum_len)]
+            print(result)
+            printed += sum_len
         #if the user already has the package installed print their installed version
         #and the latest version found on the index
         if res_key.lower() in matches.keys():
-            print("INSTALLED: {0}\nLATEST   : {1}".format(matches[res_key.lower()]['installed'], 
-                                                          matches[res_key.lower()]['latest']))
+            print("   INSTALLED: {0}\n   LATEST   : {1}".format(matches[res_key.lower()]['installed'], 
+                                                                matches[res_key.lower()]['latest']))
     return
     
     

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -16,9 +16,14 @@ def install(args):
     return
 
 def freeze(args):
-    distributions = pip2.commands.freeze.freeze(args.version)
+    if args is not None:    
+        distributions = pip2.commands.freeze.freeze(args.version)
+    else:
+        distributions = pip2.commands.freeze.freeze()
     
-    for dist_name in distributions.keys():
+    dist_names = list(distributions.keys())
+    dist_names.sort()
+    for dist_name in dist_names:
         if args.version:
             print('{0:<30}{1}'.format(dist_name[:30], distributions[dist_name]['version']))
         else:

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -23,10 +23,17 @@ def freeze(args):
     return
 
 def search(args):
-    results = pip2.commands.search.search(args.project)
+    results, matches = pip2.commands.search.search(args.package)
     
-    # ----- to do -----
-    # format/display results
+    #for each package
+    for res_key in results.keys():
+        #print the package name and summary
+        print("{0} - {1}".format(res_key, results[res_key]))
+        #if the user already has the package installed print their installed version
+        #and the latest version found on the index
+        if res_key in matches:
+            print("INSTALLED: {0}\nLATEST   : {1}".format(matches[res_key]['installed'], 
+                                                          matches[res_key]['latest']))
     
     return
     

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -20,21 +20,21 @@ def freeze(args):
     
     for dis in distributions:
         print(dis)
+        
     return
 
 def search(args):
     results, matches = pip2.commands.search.search(args.package)
     
-    #for each package
+    #for each search result
     for res_key in results.keys():
         #print the package name and summary
         print("{0} - {1}".format(res_key, results[res_key]))
         #if the user already has the package installed print their installed version
         #and the latest version found on the index
-        if res_key in matches:
-            print("INSTALLED: {0}\nLATEST   : {1}".format(matches[res_key]['installed'], 
-                                                          matches[res_key]['latest']))
-    
+        if res_key.lower() in matches.keys():
+            print("INSTALLED: {0}\nLATEST   : {1}".format(matches[res_key.lower()]['installed'], 
+                                                          matches[res_key.lower()]['latest']))
     return
     
     

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -1,7 +1,7 @@
 import pip2.commands.install
 import pip2.commands.freeze
 import pip2.commands.search
-import sys, os
+from pip2.util import getTerminalSize
 
 def install(args):
     result = pip2.commands.install.install(args.package_list)
@@ -25,7 +25,8 @@ def freeze(args):
 
 def search(args):
     results, matches = pip2.commands.search.search(args.package)
-    terminal_width = 80 #get actual terminal width somehow?
+    terminal_width = getTerminalSize()[0]
+    print(terminal_width)
     name_len = 26 #package name alotted this many characters
     # package summary alotted this many characters per line, - 4 is for the ' - ' and 
     # leaving one extra space at end

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -32,7 +32,7 @@ def freeze(args):
     return
 
 def search(args):
-    results, matches = pip2.commands.search.search(args.package)
+    results = pip2.commands.search.search(args.package)
     terminal_width = getTerminalSize()[0]
     
     name_len = 26 #package name alotted this many characters
@@ -45,21 +45,21 @@ def search(args):
         # how much of the summary we have printed
         printed = 0
         #get as much as can fit on the first line
-        summary = results[res_key][:sum_len]
+        summary = results[res_key]['summary'][:sum_len]
         result = "{0:<{2}} - {1}".format(res_key[:name_len], summary, name_len)
         print(result)
         printed += sum_len
         # while we haven't printed all of the summary
-        while(printed) < (len(results[res_key])):
+        while(printed) < (len(results[res_key]['summary'])):
             # +3 is to compensate for ' - '
-            result = " "*(name_len+3) + results[res_key][printed:(printed+sum_len)]
+            result = " "*(name_len+3) + results[res_key]['summary'][printed:(printed+sum_len)]
             print(result)
             printed += sum_len
         #if the user already has the package installed print their installed version
         #and the latest version found on the index
-        if res_key.lower() in matches.keys():
-            print("   INSTALLED: {0}\n   LATEST   : {1}".format(matches[res_key.lower()]['installed'], 
-                                                                matches[res_key.lower()]['latest']))
+        if ('installed_version' in results[res_key] and 'latest_version' in results[res_key]):
+            print("   INSTALLED: {0}\n   LATEST   : {1}".format(results[res_key]['installed_version'], 
+                                                                results[res_key]['latest_version']))
     return
     
     

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -1,5 +1,6 @@
 import pip2.commands.install
 import pip2.commands.freeze
+import pip2.commands.search
 import sys
 
 def install(args):
@@ -20,5 +21,14 @@ def freeze(args):
     for dis in distributions:
         print(dis)
     return
+
+def search(args):
+    results = pip2.commands.search.search(args.project)
+    
+    # ----- to do -----
+    # format/display results
+    
+    return
+    
     
     

--- a/pip2/commands/freeze.py
+++ b/pip2/commands/freeze.py
@@ -4,6 +4,6 @@ def freeze():
     result = distutils2.database.get_distributions()
     
     #replace the iterator of distributions with just a list of names
-    return [distribution.name.lower() for distribution in result]
+    return [distribution.name for distribution in result]
     
 

--- a/pip2/commands/freeze.py
+++ b/pip2/commands/freeze.py
@@ -1,11 +1,9 @@
-import distutils2.database as packaging
-
-get_distributions = packaging.get_distributions
+import distutils2.database 
 
 def freeze():
-    result = get_distributions()
+    result = distutils2.database.get_distributions()
     
     #replace the iterator of distributions with just their name as a list
     return [distribution.name for distribution in result]
-    #return list(result)
+    
 

--- a/pip2/commands/freeze.py
+++ b/pip2/commands/freeze.py
@@ -9,18 +9,17 @@ def freeze(version = False):
     
     for dist in results:
         installed[dist.name] = dict()
-    
-    # if the version option (-v) has been specified    
-    if version:
-        installed = _version(results, installed)
+        
+        # if the version option (-v) has been specified 
+        if version:
+            installed = _version(dist, installed)
         
     return installed
 
 
-def _version(results, installed):
-    # populate version info for each dist
-    for dist in results:
-        installed[dist.name]['version'] = dist.version
+def _version(dist, installed):
+    # populate version info for the dist
+    installed[dist.name]['version'] = dist.version
             
     return installed
     

--- a/pip2/commands/freeze.py
+++ b/pip2/commands/freeze.py
@@ -1,9 +1,27 @@
 import distutils2.database 
 
-def freeze():
-    result = distutils2.database.get_distributions()
+def freeze(version = False):
+    # dictionary to hold info about installed dists.
+    # key is dist's name, value is a dictionary to hold info populated by
+    # freeze's various options
+    installed = dict()
+    results = list(distutils2.database.get_distributions())
     
-    #replace the iterator of distributions with just a list of names
-    return [distribution.name for distribution in result]
+    for dist in results:
+        installed[dist.name] = dict()
+    
+    # if the version option (-v) has been specified    
+    if version:
+        installed = _version(results, installed)
+        
+    return installed
+
+
+def _version(results, installed):
+    # populate version info for each dist
+    for dist in results:
+        installed[dist.name]['version'] = dist.version
+            
+    return installed
     
 

--- a/pip2/commands/freeze.py
+++ b/pip2/commands/freeze.py
@@ -3,7 +3,7 @@ import distutils2.database
 def freeze():
     result = distutils2.database.get_distributions()
     
-    #replace the iterator of distributions with just their name as a list
-    return [distribution.name for distribution in result]
+    #replace the iterator of distributions with just a list of names
+    return [distribution.name.lower() for distribution in result]
     
 

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -9,20 +9,32 @@ def search(package):
 
     #dictionary to hold results. Key is package name, value is summary of package
     results = dict()
+    #dictionary to hold matches of search results and installed packages
+    #key is package name and value is dictionary with installed version and queried version
     matches = dict()
 
     #create the client to connect to package indexes
-    client = xmlrpc.Client()
+    try: #temp for future ref, fail gracefully
+        client = xmlrpc.Client()
+    except:
+        raise
     
     #get installed packages for comparisons against search results (will also need version numbers eventually)
     installed = [dis.lower() for dis in pip2.commands.freeze.freeze()]
     #search_projects returns a list of projects
-    projects = client.search_projects(name = package)
+    try: #temp for future ref
+        projects = client.search_projects(name = package)
+    except:
+        raise
     
     #for each project, which is really just a releasesList 
     for project in projects:
         #gets the latest release
-        release = project.releases[0]
+        try: #temp for future ref. Sometimes a release can't be found or version number can't be rationalized
+            release = project.releases[0]
+        except:
+            raise
+        
         results[project.name] = release.metadata['summary']
         #if this package from search results is already installed then keep track of it
         if project.name.lower() in installed:

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -20,7 +20,13 @@ def search(package):
         raise
     
     #get installed packages for comparisons against search results (will also need version numbers eventually)
-    installed = [dis.lower() for dis in pip2.commands.freeze.freeze()]
+    installed = pip2.commands.freeze.freeze(version = True)
+    
+    # convert all keys to lowercase for easy matching
+    installed_low = dict()
+    for dist_name in installed.keys():
+        installed_low[dist_name.lower()] = installed[dist_name]
+        
     #search_projects returns a list of projects
     try: #temp for future ref
         projects = client.search_projects(name = package)
@@ -37,8 +43,9 @@ def search(package):
         
         results[project.name] = release.metadata['summary']
         #if this package from search results is already installed then keep track of it
-        if project.name.lower() in installed:
-            matches[project.name.lower()] = {'installed':1.0, 'latest':release.version}
+        if project.name.lower() in installed_low.keys():
+            matches[project.name.lower()] = {'installed':installed_low[project.name.lower()]['version'], 
+                                             'latest':release.version}
         
     return results, matches
 

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -32,11 +32,15 @@ def search(package):
         projects = client.search_projects(name = package)
     except:
         raise
-    
+
     #for each project, which is really just a releasesList 
     for project in projects:
+        #print(project)
         #gets the latest release
         try: #temp for future ref. Sometimes a release can't be found or version number can't be rationalized
+            #releases = project.fetch_releases()
+            #print(releases)
+            #release = releases[0]
             release = project.releases[0]
         except:
             raise

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -1,4 +1,4 @@
-from distutils2.pypi import wrapper
+from distutils2.pypi import xmlrpc
 import pip2.commands.freeze
 
 def search(package):
@@ -6,36 +6,30 @@ def search(package):
     Searches the PYPIs for packages based off of
     the 'package' parameter, the default is the http://python.org/pypi index
     """
-    
+
     #dictionary to hold results. Key is package name, value is summary of package
     results = dict()
-    #dictionary which holds the matches from search results and already installed packages
-    #each value is also a dictionary with keys 'installed' and 'latest'
     matches = dict()
+
     #create the client to connect to package indexes
-    client = wrapper.ClientWrapper(default_index = 'xmlrpc')
+    client = xmlrpc.Client()
     
     #get installed packages for comparisons against search results (will also need version numbers eventually)
-    installed = pip2.commands.freeze.freeze()
+    installed = [dis.lower() for dis in pip2.commands.freeze.freeze()]
+    #search_projects returns a list of projects
+    projects = client.search_projects(name = package)
     
-    #search_projects returns a list of releasesLists
-    packages = client.search_projects(name = package)
-    print(packages)
-    
-    #for each package 
-    for pkg in packages:
-        #get the latest release (based off latest version)
-        print('\n{0}\n{1}\n'.format(pkg, dir(pkg)))
-        pk = client.get_releases(pkg)
-        print(pk.fetch_releases())
+    #for each project, which is really just a releasesList 
+    for project in projects:
+        #gets the latest release
+        release = project.releases[0]
+        results[project.name] = release.metadata['summary']
+        #if this package from search results is already installed then keep track of it
+        if project.name.lower() in installed:
+            matches[project.name.lower()] = {'installed':1.0, 'latest':release.version}
         
-        #add the summary of the project, which is located in the release's metadata
-        results[pkg['name']] = release.metadata.get('summary')
-        #is one of the installed packages showing up in search results?
-        if pkg['name'] in installed:
-            #'installed' will be retrieved through the freeze command, 1.0 is a place holder
-            #'latest' is retrieved from the latest release's version
-            matches[pkg['name']] = {'installed':1.0, 'latest':release.version}
-    
     return results, matches
+
+
+        
 

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -1,0 +1,4 @@
+import distutils2.pypi.wrapper as ClientWrapper
+
+def search(package):
+    return False

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -1,4 +1,41 @@
-import distutils2.pypi.wrapper as ClientWrapper
+from distutils2.pypi import wrapper
+import pip2.commands.freeze
 
 def search(package):
-    return False
+    """
+    Searches the PYPIs for packages based off of
+    the 'package' parameter, the default is the http://python.org/pypi index
+    """
+    
+    #dictionary to hold results. Key is package name, value is summary of package
+    results = dict()
+    #dictionary which holds the matches from search results and already installed packages
+    #each value is also a dictionary with keys 'installed' and 'latest'
+    matches = dict()
+    #create the client to connect to package indexes
+    client = wrapper.ClientWrapper(default_index = 'xmlrpc')
+    
+    #get installed packages for comparisons against search results (will also need version numbers eventually)
+    installed = pip2.commands.freeze.freeze()
+    
+    #search_projects returns a list of releasesLists
+    packages = client.search_projects(name = package)
+    print(packages)
+    
+    #for each package 
+    for pkg in packages:
+        #get the latest release (based off latest version)
+        print('\n{0}\n{1}\n'.format(pkg, dir(pkg)))
+        pk = client.get_releases(pkg)
+        print(pk.fetch_releases())
+        
+        #add the summary of the project, which is located in the release's metadata
+        results[pkg['name']] = release.metadata.get('summary')
+        #is one of the installed packages showing up in search results?
+        if pkg['name'] in installed:
+            #'installed' will be retrieved through the freeze command, 1.0 is a place holder
+            #'latest' is retrieved from the latest release's version
+            matches[pkg['name']] = {'installed':1.0, 'latest':release.version}
+    
+    return results, matches
+

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -7,11 +7,8 @@ def search(package):
     the 'package' parameter, the default is the http://python.org/pypi index
     """
 
-    #dictionary to hold results. Key is package name, value is summary of package
+    #dictionary to hold results. Key is package name, value is dict with summary and match info
     results = dict()
-    #dictionary to hold matches of search results and installed packages
-    #key is package name and value is dictionary with installed version and queried version
-    matches = dict()
 
     #create the client to connect to package indexes
     try: #temp for future ref, fail gracefully
@@ -38,20 +35,19 @@ def search(package):
         #print(project)
         #gets the latest release
         try: #temp for future ref. Sometimes a release can't be found or version number can't be rationalized
-            #releases = project.fetch_releases()
-            #print(releases)
-            #release = releases[0]
             release = project.releases[0]
         except:
             raise
         
-        results[project.name] = release.metadata['summary']
+        results[project.name] = {}
+        results[project.name]['summary'] = release.metadata['summary']
+        
         #if this package from search results is already installed then keep track of it
         if project.name.lower() in installed_low.keys():
-            matches[project.name.lower()] = {'installed':installed_low[project.name.lower()]['version'], 
-                                             'latest':release.version}
+            results[project.name]['installed_version'] = installed_low[project.name.lower()]['version']
+            results[project.name]['latest_version'] = release.version
         
-    return results, matches
+    return results
 
 
         

--- a/pip2/pip_parser.py
+++ b/pip2/pip_parser.py
@@ -10,6 +10,7 @@ def create_parser():
     parser_install.set_defaults(func=pip2.cli_wrapper.install)
     
     parser_freeze = subparsers.add_parser('freeze')
+    parser_freeze.add_argument('-v', '--version', action = 'store_true')
     parser_freeze.set_defaults(func=pip2.cli_wrapper.freeze)
     
     parser_search = subparsers.add_parser('search')

--- a/pip2/pip_parser.py
+++ b/pip2/pip_parser.py
@@ -12,4 +12,8 @@ def create_parser():
     parser_freeze = subparsers.add_parser('freeze')
     parser_freeze.set_defaults(func=pip2.cli_wrapper.freeze)
     
+    parser_search = subparsers.add_parser('search')
+    parser_search.add_argument('package')
+    parser_search.set_defaults(func=pip2.cli_wrapper.search)
+    
     return parser

--- a/pip2/util.py
+++ b/pip2/util.py
@@ -1,0 +1,79 @@
+def getTerminalSize():
+   import platform
+   current_os = platform.system()
+   tuple_xy=None
+   if current_os == 'Windows':
+      tuple_xy = _getTerminalSize_windows()
+      if tuple_xy is None:
+         tuple_xy = _getTerminalSize_tput()
+         # needed for window's python in cygwin's xterm!
+   if current_os == 'Linux' or current_os == 'Darwin' or  current_os.startswith('CYGWIN'):
+      tuple_xy = _getTerminalSize_linux()
+   if tuple_xy is None:
+      #print "default"
+      tuple_xy = (80, 25)      # default value
+   return tuple_xy
+
+def _getTerminalSize_windows():
+   res=None
+   try:
+      from ctypes import windll, create_string_buffer
+
+      # stdin handle is -10
+      # stdout handle is -11
+      # stderr handle is -12
+      
+      h = windll.kernel32.GetStdHandle(-12)
+      csbi = create_string_buffer(22)
+      res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
+   except:
+      return None
+   if res:
+      import struct
+      (bufx, bufy, curx, cury, wattr,
+       left, top, right, bottom, maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+      sizex = right - left + 1
+      sizey = bottom - top + 1
+      return sizex, sizey
+   else:
+      return None
+
+def _getTerminalSize_tput():
+   # get terminal width
+   # src: http://stackoverflow.com/questions/263890/how-do-i-find-the-width-height-of-a-terminal-window
+   try:
+      import subprocess
+      proc=subprocess.Popen(["tput", "cols"],stdin=subprocess.PIPE,stdout=subprocess.PIPE)
+      output=proc.communicate(input=None)
+      cols=int(output[0])
+      proc=subprocess.Popen(["tput", "lines"],stdin=subprocess.PIPE,stdout=subprocess.PIPE)
+      output=proc.communicate(input=None)
+      rows=int(output[0])
+      return (cols,rows)
+   except:
+      return None
+
+
+def _getTerminalSize_linux():
+   def ioctl_GWINSZ(fd):
+      try:
+         import fcntl, termios, struct, os
+         cr = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ,'1234'))
+      except:
+         return None
+      return cr
+   cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
+   if not cr:
+      try:
+         fd = os.open(os.ctermid(), os.O_RDONLY)
+         cr = ioctl_GWINSZ(fd)
+         os.close(fd)
+      except:
+         pass
+   if not cr:
+      try:
+         cr = (env['LINES'], env['COLUMNS'])
+      except:
+         return None
+   return int(cr[1]), int(cr[0])
+

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -2,31 +2,14 @@ import mock
 import sys
 import pip2.commands.freeze
 import pip2.cli_wrapper
-import distutils2.database as packaging
+import distutils2.database 
 from io import StringIO
 
 
-class testFreezeAPI():
+@mock.patch.object(distutils2.database, 'get_distributions')
+class TestFreezeAPI():
     
-    #save the orginal command
-    original = packaging.get_distributions   
-    
-    #creates the magicmock object and patches it to
-    #the get_distributions function
-    def setup(self):
-        #magic mock the get_distributions generator
-        get_dists = mock.MagicMock()
-        #hook it in
-        pip2.commands.freeze.get_distributions = get_dists
-        return get_dists
-    
-    #replace the magicmock object with the original command
-    def tear_down(self):
-        pip2.commands.freeze.get_distributions = self.original
-    
-    #can't patch because we need a magiMock object for the generator
-    def test_freeze_return_dist_iter(self):
-        get_dists = self.setup()
+    def test_freeze_return_dist_iter(self, mock_gen):
     
         #create the ind. distributions that the gen will return
         dis1 = mock.Mock()
@@ -37,7 +20,7 @@ class testFreezeAPI():
         dis3.name = 'test_package3'
         
         #get_distributions gen returns a iterator over distributions objects
-        get_dists.return_value = [dis1, dis2, dis3]
+        mock_gen.return_value = iter([dis1, dis2, dis3])
         
         #freeze type casts the iterator to a list before returning it
         expected = ['test_package1', 'test_package2', 'test_package3']
@@ -53,32 +36,26 @@ class testFreezeAPI():
             print('result  : {0}'.format(result))
             print('expected: {0}'.format(expected))
             raise
-        finally:
-            #clean up
-            self.tear_down()
-            
-class testFreezeCLI():
+
+@mock.patch.object(pip2.commands.freeze, 'freeze')            
+class TestFreezeCLI():
     
     originalOut = sys.stdout
-    originalCmd = pip2.commands.freeze.freeze
     
-    #capture stdout and replace freeze command with mock object
+    #capture stdout 
     def setup(self):
         sys.stdout = result = StringIO() 
-        freeze = mock.Mock()
-        pip2.commands.freeze.freeze = freeze
-        return result, freeze
+        return result
     
-    #replace stdout and freeze cmd with orignal values
+    #replace stdout 
     def tear_down(self):
         sys.stdout = self.originalOut
-        pip2.commands.freeze.freeze = self.originalCmd
     
-    def test_freeze_correct_output(self):
-        result, freeze = self.setup()
+    def test_freeze_correct_output(self, mock_func):
+        result = self.setup()
         
         #This is what the freeze API command should return
-        freeze.return_value = ['test_package1', 'test_package2', 'test_package3']        
+        mock_func.return_value = ['test_package1', 'test_package2', 'test_package3']        
         
         #run the CLI freeze command
         pip2.cli_wrapper.freeze(None)

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -5,7 +5,6 @@ import pip2.cli_wrapper
 import distutils2.database 
 from io import StringIO
 
-
 @mock.patch.object(distutils2.database, 'get_distributions')
 class TestFreezeAPI():
     

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,16 +1,59 @@
 import mock
 import pip2.commands.search
 import distutils2.pypi.xmlrpc
+import pip2.commands.freeze
 
-@mock.patch.object(distutils2.pypi.xmlrpc, 'Client')
+@mock.patch.object(pip2.commands.freeze, 'freeze')
+@mock.patch.object(distutils2.pypi.xmlrpc.Client, 'search_projects')
 class TestSearchAPI():
     
-    def test_return_correct_results(self, mock_func):
-        return False
+    def test_basic_search(self, mock_search_projects, mock_freeze):
+        
+        test_proj1 = mock.Mock()
+        test_proj1.name = 'test_proj1'
+        test_proj1.releases = mock.MagicMock()
+        test_proj1.releases[0].version = 1.5
+        test_proj1.releases[0].metadata = {}
+        test_proj1.releases[0].metadata['summary'] = 'Summary for project 1'
+        
+        test_proj2 = mock.Mock()
+        test_proj2.name = 'test_proj2'
+        test_proj2.releases = mock.MagicMock()
+        test_proj2.releases[0].version = 2.5
+        test_proj2.releases[0].metadata = {}
+        test_proj2.releases[0].metadata['summary'] = 'Summary for project 2'
+        
+        test_proj3 = mock.Mock()
+        test_proj3.name = 'test_proj3'
+        test_proj3.releases = mock.MagicMock()
+        test_proj3.releases[0].version = 3.5
+        test_proj3.releases[0].metadata = {}
+        test_proj3.releases[0].metadata['summary'] = 'Summary for project 3'
+        
+        mock_search_projects.return_value = [test_proj1, test_proj2, test_proj3]
+        mock_freeze.return_value = {'test_proj1':{'version':1.0}, 'test_proj3':{'version':3.0}}
+        
+        expected = {'test_proj1':{'summary':'Summary for project 1', 
+                                  'installed_version':1.0, 'latest_version':1.5}, 
+                    'test_proj2':{'summary':'Summary for project 2'}, 
+                    'test_proj3':{'summary':'Summary for project 3', 
+                                  'installed_version':3.0, 'latest_version':3.5}}
+        
+        result = pip2.commands.search.search('test')
+        
+        #compare the two
+        try:
+            assert result == expected
+        #not the same? print out both lists
+        except AssertionError:
+            print('result  : {0}'.format(result))
+            print('expected: {0}'.format(expected))
+            raise
+        
 
 @mock.patch.object(pip2.commands.search, 'search')    
 class TestSearchCLI():
     
-    def test_print_correct_results(self, mock_func):
+    def test_basic_search(self, mock_func):
         return False
     

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,15 +1,16 @@
 import mock
 import pip2.commands.search
+import distutils2.pypi.xmlrpc
 
-@mock.patch.object()
+@mock.patch.object(distutils2.pypi.xmlrpc, 'Client')
 class TestSearchAPI():
     
-    def test_return_correct_results():
+    def test_return_correct_results(self, mock_func):
         return False
 
-@mock.patch.object()    
+@mock.patch.object(pip2.commands.search, 'search')    
 class TestSearchCLI():
     
-    def test_print_correct_results():
+    def test_print_correct_results(self, mock_func):
         return False
     

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,2 +1,15 @@
 import mock
 import pip2.commands.search
+
+@mock.patch.object()
+class TestSearchAPI():
+    
+    def test_return_correct_results():
+        return False
+
+@mock.patch.object()    
+class TestSearchCLI():
+    
+    def test_print_correct_results():
+        return False
+    


### PR DESCRIPTION
Search works correctly now! (well kinda, there seems to be a bug with the search_projects func in xmlrpc module)

BUG: say we search for the nose package on pypi. There are multiple noses on pypi and when search_projects returns, it gives us a list of releasesLists, each nose will be in a separate releasesList, but the releaseInfos from all the noses will be propagated to each releasesList. This means when we want to get the version number of a project that has multiple copies on pypi, we aren't guaranteed to get the correct version number!

Added -v command to freeze! Added tests for -v command for API and CLI.
Added basic test for search API, not CLI yet.
