### PR TITLE
Switched to packaging from distutils2

### DIFF
--- a/pip2/commands/freeze.py
+++ b/pip2/commands/freeze.py
@@ -1,11 +1,11 @@
-import distutils2.database 
+import packaging.database 
 
 def freeze(version = False):
     # dictionary to hold info about installed dists.
     # key is dist's name, value is a dictionary to hold info populated by
     # freeze's various options
     installed = dict()
-    results = list(distutils2.database.get_distributions())
+    results = list(packaging.database.get_distributions())
     
     for dist in results:
         installed[dist.name] = dict()

--- a/pip2/commands/install.py
+++ b/pip2/commands/install.py
@@ -1,10 +1,10 @@
-import distutils2.install
+import packaging.install
 
 def install(package_list):
     result = {'installed':[], 'failed':[]}
 
     for package in package_list:
-        if distutils2.install.install(package):
+        if packaging.install.install(package):
             result['installed'].append(package)
         else:
             result['failed'].append(package)

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -1,4 +1,4 @@
-from distutils2.pypi import xmlrpc
+from packaging.pypi import xmlrpc
 import pip2.commands.freeze
 
 def search(package):

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -2,10 +2,10 @@ import mock
 import sys
 import pip2.commands.freeze
 import pip2.cli_wrapper
-import distutils2.database 
+import packaging.database 
 from io import StringIO
 
-@mock.patch.object(distutils2.database, 'get_distributions')
+@mock.patch.object(packaging.database, 'get_distributions')
 class TestFreezeAPI():
     
     def test_basic_freeze(self, mock_gen):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,8 +1,8 @@
 import mock
 import pip2.commands.install
-import distutils2.install
+import packaging.install
 
-@mock.patch.object(distutils2.install, 'install')
+@mock.patch.object(packaging.install, 'install')
 class TestInstallAPI():
 
     def test_install_single_package(self, mock_func):
@@ -38,7 +38,7 @@ class TestInstallAPI():
         assert result['failed'] == expected
 
 
-@mock.patch.object(distutils2.install, 'install')
+@mock.patch.object(packaging.install, 'install')
 class TestInstallCLI():
     
     def test_install_single_package(self, mock_func):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,10 +1,10 @@
 import mock
 import pip2.commands.search
-import distutils2.pypi.xmlrpc
+import packaging.pypi.xmlrpc
 import pip2.commands.freeze
 
 @mock.patch.object(pip2.commands.freeze, 'freeze')
-@mock.patch.object(distutils2.pypi.xmlrpc.Client, 'search_projects')
+@mock.patch.object(packaging.pypi.xmlrpc.Client, 'search_projects')
 class TestSearchAPI():
     
     def test_basic_search(self, mock_search_projects, mock_freeze):


### PR DESCRIPTION
Since we should be developing on Python 3.3 from now on, we should switch to using packaging.
