### PR TITLE
Support both Python 3.2 and 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pip.log
 .idea/*
 *.swp
 RECORD
+.tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -9,17 +9,17 @@ Contributing with Code
 Supported Python Versions
 -------------------------
 
-Pip2 only supports Python 3.2 at the moment, but there are plans to support
-versions of Python back to 2.6 (ish?).
+Pip2 currently only supports Python 3.2 and 3.3 (scheduled for release in
+August 2012), but there are plans to support versions of Python back to
+2.6-ish.
 
 Prerequisites
 -------------
 
 The following tools are required:
 
+- Python 3.2 or 3.3 (preferably both)
 - Git
-- Mercurial (``hg``)
-- Python 3.2
 - pip and virtualenv
 
 You must also have a Github account and basic familiarity with the tools listed
@@ -42,17 +42,19 @@ fork::
 Installation
 ------------
 
-Create and activate a virtualenv for pip2 development with Python 3.2::
+Create and activate a virtualenv for pip2 development. For example, if you are
+developing with Python 3.2::
 
     $ virtualenv --python=python3.2 pip2-dev-py3.2
     $ source pip2-dev-py3.2/bin/activate
 
-Pip2 depends on distutils2, which doesn't have a recent version on PyPI. To
-install the python3 branch of distutils2 from source::
+For versions of Python prior to 3.3, pip2 depends on distutils2 which is often
+`broken`_ and/or outdated on PyPI. For now, just use pip to install from the
+python3 branch of the distutils2 repository::
 
-    $ hg clone --branch python3 http://hg.python.org/distutils2
-    $ pip install -e distutils2/
+    $ pip install http://hg.python.org/distutils2/archive/python3.tar.bz2
 
+.. _broken: http://github.com/osupython/pip2/issues/45
 
 Install pip2::
 
@@ -62,7 +64,42 @@ Install pip2::
 Running the Tests
 -----------------
 
-TODO
+Pip2 uses `nose`_ and `mock`_ for testing. To install nose::
+
+    $ pip install nose
+
+Mock has been included in Python's standard library since version 3.3. For
+versions of Python prior to 3.3::
+
+    $ pip install mock
+
+.. _nose: http://nose.readthedocs.org/
+.. _mock: http://www.voidspace.org.uk/python/mock/
+
+Now, run the unit tests from the root directory of the pip2 repository. You
+should run these tests frequently as you are modifying the code::
+
+    $ nosetests
+
+Once your changes are working well in your development environment, `tox`_ can
+be used to run these same tests in a clean environment under multiple versions
+of Python. First, install tox::
+
+    $ pip install tox
+
+The first time you run it, tox will take a while (quite a few minutes) to build
+virtualenvs and install the required packages::
+
+    $ tox
+
+Subsequent tox runs will reuse the existing virtualenvs and run much faster.
+Note, however, that you may want to occasionally force the virtualenvs to be
+recreated by running `tox --recreate` to get the latest versions of pip2's
+dependencies. Run `tox --help`, visit `tox's website`_, or view the `tox.ini`
+file in pip2's repository for additional information on using tox.
+
+.. _tox: http://tox.readthedocs.org/
+.. _tox's website: http://tox.readthedocs.org/
 
 
 Contributing with Documentation

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -4,12 +4,14 @@ line.
 
 """
 
+import sys
+
 import pip2.commands.install
 import pip2.commands.uninstall
 import pip2.commands.freeze
 import pip2.commands.search
 import pip2.util
-import sys
+
 
 # TODO: Add options to match pip feature set
 

--- a/pip2/commands/freeze.py
+++ b/pip2/commands/freeze.py
@@ -5,7 +5,7 @@ return: A dictionary, key is package name value is a dictionary with
         information about package.
 """
 
-import packaging.database
+from pip2.compat import packaging
 
 
 def freeze():

--- a/pip2/commands/install.py
+++ b/pip2/commands/install.py
@@ -3,8 +3,9 @@ Installs a package and returns a dictionary containing which packages
 were installed successfully or unsuccessfully.
 """
 
-import packaging.install
 import os
+
+from pip2.compat import packaging
 
 
 def install(package_list):

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -8,9 +8,11 @@ return: A dictionary of search results. Key is package name value is dictionary
         containing information about the package.
 """
 
-import packaging.pypi.xmlrpc
-import pip2.commands.freeze
 import logging
+
+import pip2.commands.freeze
+from pip2.compat import packaging
+
 
 pkg_logger = logging.getLogger("packaging")
 old_lvl = pkg_logger.getEffectiveLevel()

--- a/pip2/commands/uninstall.py
+++ b/pip2/commands/uninstall.py
@@ -3,7 +3,7 @@ Uninstalls a package and returns a dictionary containing which packages
 were uninstalled successfully or unsuccessfully.
 """
 
-import packaging.install
+from pip2.compat import packaging
 
 
 def uninstall(package_list):

--- a/pip2/compat.py
+++ b/pip2/compat.py
@@ -1,0 +1,27 @@
+"""Stuff that differs in different Python versions."""
+
+import sys
+
+
+if sys.version_info >= (3, 3):
+    import packaging
+    import packaging.database
+    import packaging.install
+    import packaging.pypi
+    try:
+        import unittest.mock as mock
+    except ImportError:
+        # Mock isn't needed for normal functionality, so don't worry if it
+        # can't be imported here; the tests will complain if they need it
+        pass
+else:
+    import distutils2 as packaging
+    import distutils2.database
+    import distutils2.install
+    import distutils2.pypi
+    try:
+        import mock
+    except ImportError:
+        # Mock isn't needed for normal functionality, so don't worry if it
+        # can't be imported here; the tests will complain if they need it
+        pass

--- a/pip2/pip_parser.py
+++ b/pip2/pip_parser.py
@@ -3,6 +3,7 @@ Command line argument parser
 """
 
 import argparse
+
 import pip2.cli_wrapper
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-import sys
 import os
+import sys
 from setuptools import setup
+
 
 version = "0.0.1"
 

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,39 @@
 import os
 import sys
+
 from setuptools import setup
 
 
 version = "0.0.1"
 
-long_description = """
+install_requires = []
 
-Experimental port of pip to use the distutils2 packaging library.
+if sys.version_info < (3, 3):
+    # Distutils2 on PyPI doesn't work for Python 3, so we aren't listing it as
+    # a dependency yet (see Github issue 45)
+    #install_requires.append('distutils2')
+    pass
 
-"""
 
 setup(name="pip2",
       version=version,
       description="Experimental port of pip to use distutils2.",
-      long_description=long_description,
+      long_description=open('README.rst').read(),
       classifiers=[
           'Development Status :: 2 - Pre-Alpha',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: MIT License',
           'Topic :: Software Development :: Build Tools',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.1',
           'Programming Language :: Python :: 3.2',
+          'Programming Language :: Python :: 3.3',
       ],
-      keywords='easy_install distutils2 setuptools egg virtualenv',
+      keywords='pip packaging distutils2 easy_install setuptools',
       author='OSUPython Senior Design Team',
       author_email='osupython@gmail.com',
-      url='http://https://github.com/osupython/pip2',
+      url='http://github.com/osupython/pip2',
       license='MIT',
       packages=['pip2', 'pip2.commands'],
       entry_points=dict(console_scripts=['pip2=pip2:main']),
-      test_suite='nose.collector',
-      tests_require=['nose', 'virtualenv>=1.7', 'scripttest>=1.1.1', 'mock'],
+      install_requires=install_requires,
       zip_safe=False)

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -1,10 +1,11 @@
-import mock
-import sys
 import inspect
-import pip2.commands.freeze
-import pip2.cli_wrapper
-import packaging.database
+import sys
 from io import StringIO
+
+import pip2.cli_wrapper
+import pip2.commands.freeze
+from pip2.compat import mock
+from pip2.compat import packaging
 
 
 @mock.patch.object(packaging.database, 'get_distributions')

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,8 +1,8 @@
-import mock
-import pip2.commands.install
-import packaging.install
 import os
-import tempfile
+
+import pip2.commands.install
+from pip2.compat import mock
+from pip2.compat import packaging
 
 
 @mock.patch.object(packaging.install, 'install')

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,10 +1,11 @@
-from io import StringIO
 import inspect
-import mock
 import sys
-import pip2.commands.search
-import packaging.pypi.xmlrpc
+from io import StringIO
+
 import pip2.commands.freeze
+import pip2.commands.search
+from pip2.compat import mock
+from pip2.compat import packaging
 
 
 @mock.patch.object(pip2.commands.freeze, 'freeze')

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -2,9 +2,9 @@
 Mock testing for uninstall command.
 """
 
-import mock
 import pip2.commands.uninstall
-import packaging.install
+from pip2.compat import mock
+from pip2.compat import packaging
 
 
 @mock.patch.object(packaging.install, 'remove')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py32,py33
+
+[testenv:py32]
+commands =
+    nosetests {posargs}
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
+deps =
+    nose
+    sphinx
+    mock
+    http://hg.python.org/distutils2/archive/python3.tar.bz2
+
+[testenv:py33]
+basepython = python3.3
+commands =
+    nosetests {posargs}
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
+deps =
+    nose
+    sphinx


### PR DESCRIPTION
- Add support for Python 3.2 (in addition to 3.3)
- Comment out html_static_path to silence warning
- Support tox for running tests under multiple envs
- Update contrib docs for 3.2/3.3 support and tests
- Clean up setup.py
