### PR TITLE
Install now checks if package is local

### DIFF
--- a/pip2/commands/install.py
+++ b/pip2/commands/install.py
@@ -4,13 +4,21 @@ were installed successfully or unsuccessfully.
 """
 
 import packaging.install
+import os
 
-# TODO: Install dependencies automatically
+
 def install(package_list):
     result = {'installed': [], 'failed': []}
 
     for package in package_list:
-        if packaging.install.install(package):
+        success = False
+
+        if os.path.exists(package):
+            success = packaging.install.install_local_project(package)
+        else:
+            success = packaging.install.install(package)
+
+        if success:
             result['installed'].append(package)
         else:
             result['failed'].append(package)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,6 +1,8 @@
 import mock
 import pip2.commands.install
 import packaging.install
+import tempfile
+
 
 @mock.patch.object(packaging.install, 'install')
 class TestInstallAPI():
@@ -37,10 +39,24 @@ class TestInstallAPI():
         assert result['installed'] == []
         assert result['failed'] == expected
 
+    @mock.patch.object(packaging.install, 'install_local_project')
+    def test_local_project(self, mock_local, mock_install):
+        file1 = tempfile.NamedTemporaryFile()
+        file2 = "#"
+        mock_local.return_value = True
+        mock_install.return_value = True
+
+        pip2.commands.install.install(file1.name)
+        assert mock_local.called == True
+        pip2.commands.install.install(file2)
+        assert mock_install.called == True
+
+
+
 
 @mock.patch.object(packaging.install, 'install')
 class TestInstallCLI():
-    
+
     def test_install_single_package(self, mock_func):
         pass
 
@@ -52,4 +68,3 @@ class TestInstallCLI():
 
     def test_install_fail_multiple_packages(self, mock_func):
         pass
-

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,6 +1,7 @@
 import mock
 import pip2.commands.install
 import packaging.install
+import os
 import tempfile
 
 
@@ -40,15 +41,17 @@ class TestInstallAPI():
         assert result['failed'] == expected
 
     @mock.patch.object(packaging.install, 'install_local_project')
-    def test_local_project(self, mock_local, mock_install):
-        file1 = tempfile.NamedTemporaryFile()
-        file2 = "#"
+    @mock.patch.object(os.path, 'exists')
+    def test_local_project(self, mock_os, mock_local, mock_install):
         mock_local.return_value = True
         mock_install.return_value = True
 
-        pip2.commands.install.install(file1.name)
+        mock_os.return_value = True
+        pip2.commands.install.install("test")
         assert mock_local.called == True
-        pip2.commands.install.install(file2)
+
+        mock_os.return_value = False
+        pip2.commands.install.install("test")
         assert mock_install.called == True
 
 


### PR DESCRIPTION
pip2.commands.install now checks if a package is local and attempts to install if from the local machine if so. 
The check is performed using os.path.exists. If a package is detected to be local, it will be installed with packaging.install.install_local_project and if it is not detected to be local it will be instally from Pypi (or other index) using packaging.install.install.
