### PR TITLE
Test mixed results for install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@ Example::
     Successfully installed package2 package3
     $ pip2 install package_that_doesnt_exist_or_fails_to_install
     Failed to install package_that_doesnt_exist_or_fails_to_install
+    $ pip2 install a-real-package not-a-package
+    Successfully installed a-real-package.
+    Failed to install not-a-package.
 
 
 Freeze

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8,32 +8,32 @@ import tempfile
 @mock.patch.object(packaging.install, 'install')
 class TestInstallAPI():
 
-    def test_install_single_package(self, mock_func):
-        mock_func.return_value = True
+    def test_install_single_package(self, mock_install):
+        mock_install.return_value = True
         expected = ['test_package1']
         result = pip2.commands.install.install(expected)
 
         assert result['installed'] == expected
         assert result['failed'] == []
 
-    def test_install_multiple_packages(self, mock_func):
-        mock_func.return_value = True
+    def test_install_multiple_packages(self, mock_install):
+        mock_install.return_value = True
         expected = ['test_package1', 'test_package2', 'test_package3']
         result = pip2.commands.install.install(expected)
 
         assert result['installed'] == expected
         assert result['failed'] == []
 
-    def test_install_fail_single_package(self, mock_func):
-        mock_func.return_value = False
+    def test_install_fail_single_package(self, mock_install):
+        mock_install.return_value = False
         expected = ['failing_package']
         result = pip2.commands.install.install(expected)
 
         assert result['installed'] == []
         assert result['failed'] == expected
 
-    def test_install_fail_multiple_packages(self, mock_func):
-        mock_func.return_value = False
+    def test_install_fail_multiple_packages(self, mock_install):
+        mock_install.return_value = False
         expected = ['test_package1', 'test_package2']
         result = pip2.commands.install.install(expected)
 
@@ -55,19 +55,17 @@ class TestInstallAPI():
         assert mock_install.called == True
 
 
-
-
 @mock.patch.object(packaging.install, 'install')
 class TestInstallCLI():
 
     def test_install_single_package(self, mock_func):
         pass
 
-    def test_install_multiple_packages(self, mock_func):
+    def test_install_multiple_packages(self, mock_install):
         pass
 
-    def test_install_fail_single_package(self, mock_func):
+    def test_install_fail_single_package(self, mock_install):
         pass
 
-    def test_install_fail_multiple_packages(self, mock_func):
+    def test_install_fail_multiple_packages(self, mock_install):
         pass

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -54,6 +54,21 @@ class TestInstallAPI():
         pip2.commands.install.install("test")
         assert mock_install.called == True
 
+    def test_install_mixed_results(self, mock_install):
+        # The current expected behavior is to allow some packages to be
+        # installed even if there other packages fail to install.  In the
+        # future, it will probably be all or nothing.  See issue #51 for more
+        # details.
+
+        returns = [True, False]
+        mock_install.side_effect = lambda *args: returns.pop(0)
+        successes = ['a-real-package']
+        failures = ['not-a-package']
+        result = pip2.commands.install.install(successes + failures)
+
+        assert result['installed'] == successes
+        assert result['failed'] == failures
+
 
 @mock.patch.object(packaging.install, 'install')
 class TestInstallCLI():


### PR DESCRIPTION
Add a test (and update the README) for the case where you are installing two packages, one the ends of succeeding and one that ends up failing. The current expected behavior is to allow some packages to be installed even if there other packages fail to install. In the future, it will probably be all or nothing. See issue #51 for more details.
