### PR TITLE
Search mod

### DIFF
--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -78,7 +78,8 @@ def search(args):
             print("SKIPPING RESULT: CANNOT DISPLAY UNKNOWN CHARACTERS")
             res_cnt += 1
             continue
-        if not _search_safe_print(line, res):
+        success = _search_safe_print(line, res)
+        if not success:
             res_cnt += 1
             continue
         printed += sum_len
@@ -93,7 +94,7 @@ def search(args):
         if ('installed_version' in results[res] and
             'latest_version' in results[res] and
             success):
-            print("   INSTALLED: {0}\n   LATEST   : {1}".format(results[res]['installed_version'], results[res]['latest_version']))
+            print("\tINSTALLED: {0}\n\tLATEST   : {1}".format(results[res]['installed_version'], results[res]['latest_version']))
         res_cnt += 1
         if res_cnt % res_page == 0:
             try:

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -1,5 +1,6 @@
 """
-Formats data returned from the various commands to be displayed on command line.
+Formats data returned from the various commands to be displayed on command
+line.
 
 """
 
@@ -17,11 +18,11 @@ def install(args):
     result = pip2.commands.install.install(args.package_list)
 
     if result['installed'] != []:
-        successful = " ".join(map(str, result['installed']))
-        print("Successfully installed {0}.".format(successful))
+        successful = ' '.join(map(str, result['installed']))
+        print('Successfully installed {0}.'.format(successful))
     if result['failed'] != []:
-        failed = " ".join(map(str, result['failed']))
-        print("Failed to install {0}.".format(failed))
+        failed = ' '.join(map(str, result['failed']))
+        print('Failed to install {0}.'.format(failed))
 
     return
 
@@ -30,11 +31,11 @@ def uninstall(args):
     result = pip2.commands.uninstall.uninstall(args.package_list)
 
     if result['uninstalled'] != []:
-        successful = " ".join(map(str, result['uninstalled']))
-        print("Successfully uninstalled {0}.".format(successful))
+        successful = ' '.join(map(str, result['uninstalled']))
+        print('Successfully uninstalled {0}.'.format(successful))
     if result['failed'] != []:
-        failed = " ".join(map(str, result['failed']))
-        print("Failed to uninstall {0}.".format(failed))
+        failed = ' '.join(map(str, result['failed']))
+        print('Failed to uninstall {0}.'.format(failed))
 
     return
 
@@ -44,21 +45,21 @@ def freeze(args):
     dist_names = list(distributions.keys())
     dist_names.sort()
     for dist_name in dist_names:
-        print(dist_name + "==" + distributions[dist_name]['version'])
+        print(dist_name + '==' + distributions[dist_name]['version'])
     return
 
 
 def search(args):
     results = pip2.commands.search.search(args.package)
     if results == {}:
-        print("Search returned no results...")
+        print('Search returned no results...')
         return
     # when cli_wrapper gets split into multiple files, one for each command
     # these will be global
     res_page = 50
     term_width = pip2.util.getTerminalSize()[0]
     # separator to use for name and summary
-    sep = " - "
+    sep = ' - '
     # package name alotted this many characters
     name_len = 26
     # the '- 1' is so we don't get a newline
@@ -71,11 +72,11 @@ def search(args):
         # get as much as can fit on the first line
         summary = results[res]['summary'][:sum_len]
         try:
-            line = "{0:<{1}}{2}{3}".format(res[:name_len], name_len,
+            line = '{0:<{1}}{2}{3}'.format(res[:name_len], name_len,
                                            sep, summary)
         # international packages have encoding issues, we just skip and move on
         except SystemError:
-            print("SKIPPING RESULT: CANNOT DISPLAY UNKNOWN CHARACTERS")
+            print('SKIPPING RESULT: CANNOT DISPLAY UNKNOWN CHARACTERS')
             res_cnt += 1
             continue
         success = _search_safe_print(line, res)
@@ -85,7 +86,7 @@ def search(args):
         printed += sum_len
         # while we haven't printed all of the summary
         while(printed < len(results[res]['summary'])):
-            next_line = " " * (name_len + len(sep)) + \
+            next_line = ' ' * (name_len + len(sep)) + \
                 results[res]['summary'][printed:(printed + sum_len)]
             success = _search_safe_print(next_line)
             if not success:
@@ -94,11 +95,14 @@ def search(args):
         if ('installed_version' in results[res] and
             'latest_version' in results[res] and
             success):
-            print("\tINSTALLED: {0}\n\tLATEST   : {1}".format(results[res]['installed_version'], results[res]['latest_version']))
+            print('\tINSTALLED: {0}\n\tLATEST   : {1}'.format(
+                  results[res]['installed_version'],
+                  results[res]['latest_version']))
         res_cnt += 1
         if res_cnt % res_page == 0:
             try:
-                input("\n{0}/{1} results displayed, press ENTER for more...\n".format(res_cnt, len(results.keys())))
+                input('\n{0}/{1}'.format(res_cnt, len(results.keys())) +
+                      ' results displayed, press ENTER for more...\n')
             except KeyboardInterrupt:
                 return
     return
@@ -106,19 +110,21 @@ def search(args):
 
 def _search_safe_print(string, name=None):
     # temp assignment, will be removed when search cli is in its own file
-    sep = " - "
+    sep = ' - '
     name_len = 26
     try:
         print(string)
     except (UnicodeDecodeError, UnicodeEncodeError, UnicodeError):
         if name:
-            # try and print just the package name incase the summary is causing the exception
+            # try and print just the package name incase the summary is causing
+            # the exception
             try:
-                print("{0:<{1}}{2}".format(name[:name_len], name_len, sep) +
-                      "CANNOT DISPLAY SUMMARY WITH " +
-                      "({0}) ENCODING".format(sys.getdefaultencoding()))
+                print('{0:<{1}}{2}'.format(name[:name_len], name_len, sep) +
+                      'CANNOT DISPLAY SUMMARY WITH ' +
+                      '({0}) ENCODING'.format(sys.getdefaultencoding()))
             except (UnicodeDecodeError, UnicodeEncodeError, UnicodeError):
-                print("SKIPPING RESULT: CANNOT DISPLAY WITH {0} ENCODING".format(sys.getdefaultencoding()))
+                print('SKIPPING RESULT: CANNOT DISPLAY WITH ' +
+                      '({0}) ENCODING'.format(sys.getdefaultencoding()))
                 return False
             else:
                 return True

--- a/pip2/commands/freeze.py
+++ b/pip2/commands/freeze.py
@@ -1,8 +1,8 @@
 """
 Returns a dictionary containing all installed packages.
 
-return: A dictionary, key is package name value is a dictionary
-        with information about package.
+return: A dictionary, key is package name value is a dictionary with
+        information about package.
 """
 
 import packaging.database

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -15,13 +15,14 @@ import logging
 pkg_logger = logging.getLogger("packaging")
 old_lvl = pkg_logger.getEffectiveLevel()
 
+
 def search(package):
     """
     Searches the PYPIs for packages based off of
     the 'package' parameter, the default is the http://python.org/pypi index
     """
     results = dict()
-    
+
     # temp for future ref, fail gracefully
     try:
         client = packaging.pypi.xmlrpc.Client()
@@ -38,7 +39,7 @@ def search(package):
     finally:
         pkg_logger.setLevel(old_lvl)
     installed = pip2.commands.freeze.freeze()
-    
+
     for project in projects:
         results[project.name] = dict()
         # temp for future ref.
@@ -56,7 +57,8 @@ def search(package):
             f = f.replace('\n', ' ').replace('\t', ' ').replace('  ', ' ')
             results[project.name]['summary'] = f
             if project.name in installed.keys():
-                results[project.name]['installed_version'] = installed[project.name]['version']
+                results[project.name]['installed_version'] = \
+                installed[project.name]['version']
                 results[project.name]['latest_version'] = release.version
 
     return results

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -15,13 +15,13 @@ import logging
 pkg_logger = logging.getLogger("packaging")
 old_lvl = pkg_logger.getEffectiveLevel()
 
-
 def search(package):
     """
     Searches the PYPIs for packages based off of
     the 'package' parameter, the default is the http://python.org/pypi index
     """
     results = dict()
+    
     # temp for future ref, fail gracefully
     try:
         client = packaging.pypi.xmlrpc.Client()
@@ -32,13 +32,13 @@ def search(package):
     pkg_logger.setLevel(logging.ERROR)
     # temp for future ref
     try:
-        projects = client.search_projects(name=package)
+        projects = client.search_projects(name=package, summary=package)
     except:
         raise
     finally:
         pkg_logger.setLevel(old_lvl)
     installed = pip2.commands.freeze.freeze()
-
+    
     for project in projects:
         results[project.name] = dict()
         # temp for future ref.
@@ -46,6 +46,7 @@ def search(package):
         # version number can't be rationalized
         try:
             # get the latest release
+            project.sort_releases()
             release = project.releases[0]
         except IndexError:
             results[project.name]['summary'] = "CANNOT GET SUMMARY"

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -1,8 +1,11 @@
-import mock, sys, inspect
+import mock
+import sys
+import inspect
 import pip2.commands.freeze
 import pip2.cli_wrapper
-import packaging.database 
+import packaging.database
 from io import StringIO
+
 
 @mock.patch.object(packaging.database, 'get_distributions')
 class TestFreezeAPI():
@@ -17,10 +20,11 @@ class TestFreezeAPI():
         dis3 = mock.Mock()
         dis3.name = 'test_package3'
         dis3.version = '3.0'
-        
+
         # get_distributions gen returns a iterator over distributions objects
         mock_gen.return_value = iter([dis1, dis2, dis3])
-        expected = {'test_package1':{'version':'1.0'}, 'test_package2':{'version':'2.0'}, 'test_package3':{'version':'3.0'}}
+        expected = {'test_package1': {'version': '1.0'}, 'test_package2':
+                    {'version': '2.0'}, 'test_package3': {'version': '3.0'}}
         # run the command
         result = pip2.commands.freeze.freeze()
         try:
@@ -29,25 +33,28 @@ class TestFreezeAPI():
             print('result  : {0}'.format(result))
             print('expected: {0}'.format(expected))
             raise
-        
 
-@mock.patch.object(pip2.commands.freeze, 'freeze')            
+
+@mock.patch.object(pip2.commands.freeze, 'freeze')
 class TestFreezeCLI():
     originalOut = sys.stdout
-    
-    #capture stdout 
+
+    #capture stdout
     def setup(self):
-        sys.stdout = result = StringIO() 
+        sys.stdout = result = StringIO()
         return result
-            
+
     def test_basic_freeze(self, mock_func):
         args = mock.Mock()
         result = self.setup()
-        mock_func.return_value = {'test_package1':{'version':'1.0'}, 'test_package2':{'version':'2.0'}, 'test_package3':{'version':'3.0'}}
+        mock_func.return_value = {'test_package1': {'version': '1.0'},
+                                  'test_package2': {'version': '2.0'},
+                                  'test_package3': {'version': '3.0'}}
         pip2.cli_wrapper.freeze(args)
-        expected = 'test_package1==1.0\ntest_package2==2.0\ntest_package3==3.0\n'
+        expected = 'test_package1==1.0\ntest_package2==2.0\n' + \
+                   'test_package3==3.0\n'
         self.tear_down(result.getvalue(), expected)
-                   
+
     def tear_down(self, result, expected):
         try:
             assert result == expected
@@ -55,18 +62,11 @@ class TestFreezeCLI():
             # display newlines for easier comparison
             result = result.replace('\n', '\\n')
             expected = expected.replace('\n', '\\n')
-            output = ("\n\nTEST FAILED" +
-                      "\nFunction: {0}".format(inspect.stack()[1][3]) +
-                      "\nResult  : {0}\n".format(result) +
-                      "\nExpected: {0}".format(expected))
+            output = ('\n\nTEST FAILED' +
+                      '\nFunction: {0}'.format(inspect.stack()[1][3]) +
+                      '\nResult  : {0}\n'.format(result) +
+                      '\nExpected: {0}'.format(expected))
             print(output, file=sys.stderr)
             raise
         finally:
             sys.stdout = self.originalOut
-
-
-        
-        
-
-        
-        

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,21 +13,21 @@ class TestSearchAPI():
         test_proj1 = mock.Mock()
         test_proj1.name = 'test_proj1'
         test_proj1.releases = mock.MagicMock()
-        test_proj1.releases[0].version = 1.5
+        test_proj1.releases[0].version = '1.5'
         test_proj1.releases[0].metadata = {}
         test_proj1.releases[0].metadata['summary'] = 'Summary for project 1'
         
         test_proj2 = mock.Mock()
         test_proj2.name = 'test_proj2'
         test_proj2.releases = mock.MagicMock()
-        test_proj2.releases[0].version = 2.5
+        test_proj2.releases[0].version = '2.5'
         test_proj2.releases[0].metadata = {}
         test_proj2.releases[0].metadata['summary'] = 'Summary for project 2'
         
         test_proj3 = mock.Mock()
         test_proj3.name = 'test_proj3'
         test_proj3.releases = mock.MagicMock()
-        test_proj3.releases[0].version = 3.5
+        test_proj3.releases[0].version = '3.5'
         test_proj3.releases[0].metadata = {}
         test_proj3.releases[0].metadata['summary'] = 'Summary for project 3'
         
@@ -47,13 +47,13 @@ class TestSearchAPI():
 
     def test_basic_search_matches(self, mock_search_projects, mock_freeze):
         mock_search_projects.return_value = self.setup()
-        mock_freeze.return_value = {'test_proj1':{'version':1.0}, 'test_proj3':{'version':3.0}}
+        mock_freeze.return_value = {'test_proj1':{'version':'1.0'}, 'test_proj3':{'version':'3.0'}}
         
         expected = {'test_proj1':{'summary':'Summary for project 1', 
-                                  'installed_version':1.0, 'latest_version':1.5}, 
+                                  'installed_version':'1.0', 'latest_version':'1.5'}, 
                     'test_proj2':{'summary':'Summary for project 2'}, 
                     'test_proj3':{'summary':'Summary for project 3', 
-                                  'installed_version':3.0, 'latest_version':3.5}}
+                                  'installed_version':'3.0', 'latest_version':'3.5'}}
         result = pip2.commands.search.search('test')
         
         self.tear_down(result, expected)
@@ -144,8 +144,17 @@ class TestSearchCLI():
         result = self.setup()
         self.args.package = "pkgPlaceholder"
         mock_getTerminalSize.return_value = (self.term_size, None)
-        
-        assert 0
+        installed = '1.0'
+        latest = '1.5'
+        desc = 'X'*self.sum_len
+        mock_search.return_value = {self.args.package:{'summary':desc, 
+                                    'installed_version':installed, 
+                                    'latest_version':latest}}
+        expected = (self.args.package + ' '*(self.name_len - len(self.args.package)) + 
+                    self.cli_sep + desc + '\n\tINSTALLED: ' + installed + 
+                    '\n\tLATEST   : ' + latest + '\n')
+        pip2.cli_wrapper.search(self.args)
+        self.tear_down(result.getvalue(), expected)
     
     def test_basic_display_small_terminal_size(self, mock_search, mock_getTerminalSize):
         self.term_size = 60
@@ -165,7 +174,7 @@ class TestSearchCLI():
         self.test_basic_display_name_long()
         self.test_basic_display_sum_single_line()
         self.test_basic_display_sum_word_wrap()
-        #self.test_basic_display_matches()
+        self.test_basic_display_matches()
       
     def tear_down(self, result, expected):
         try:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,14 +1,15 @@
 from io import StringIO
 import inspect
-import mock, sys
+import mock
+import sys
 import pip2.commands.search
 import packaging.pypi.xmlrpc
 import pip2.commands.freeze
 
+
 @mock.patch.object(pip2.commands.freeze, 'freeze')
 @mock.patch.object(packaging.pypi.xmlrpc.Client, 'search_projects')
 class TestSearchAPI():
-    
     def setup(self):
         test_proj1 = mock.Mock()
         test_proj1.name = 'test_proj1'
@@ -16,48 +17,51 @@ class TestSearchAPI():
         test_proj1.releases[0].version = '1.5'
         test_proj1.releases[0].metadata = {}
         test_proj1.releases[0].metadata['summary'] = 'Summary for project 1'
-        
+
         test_proj2 = mock.Mock()
         test_proj2.name = 'test_proj2'
         test_proj2.releases = mock.MagicMock()
         test_proj2.releases[0].version = '2.5'
         test_proj2.releases[0].metadata = {}
         test_proj2.releases[0].metadata['summary'] = 'Summary for project 2'
-        
+
         test_proj3 = mock.Mock()
         test_proj3.name = 'test_proj3'
         test_proj3.releases = mock.MagicMock()
         test_proj3.releases[0].version = '3.5'
         test_proj3.releases[0].metadata = {}
         test_proj3.releases[0].metadata['summary'] = 'Summary for project 3'
-        
+
         return [test_proj1, test_proj2, test_proj3]
-        
+
     def test_basic_search(self, mock_search_projects, mock_freeze):
         mock_search_projects.return_value = self.setup()
         mock_freeze.return_value = {}
-        
-        expected = {'test_proj1':{'summary':'Summary for project 1'}, 
-                    'test_proj2':{'summary':'Summary for project 2'}, 
-                    'test_proj3':{'summary':'Summary for project 3'}}
-        
+
+        expected = {'test_proj1': {'summary': 'Summary for project 1'},
+                    'test_proj2': {'summary': 'Summary for project 2'},
+                    'test_proj3': {'summary': 'Summary for project 3'}}
+
         result = pip2.commands.search.search('test')
-        
+
         self.tear_down(result, expected)
 
     def test_basic_search_matches(self, mock_search_projects, mock_freeze):
         mock_search_projects.return_value = self.setup()
-        mock_freeze.return_value = {'test_proj1':{'version':'1.0'}, 'test_proj3':{'version':'3.0'}}
-        
-        expected = {'test_proj1':{'summary':'Summary for project 1', 
-                                  'installed_version':'1.0', 'latest_version':'1.5'}, 
-                    'test_proj2':{'summary':'Summary for project 2'}, 
-                    'test_proj3':{'summary':'Summary for project 3', 
-                                  'installed_version':'3.0', 'latest_version':'3.5'}}
+        mock_freeze.return_value = {'test_proj1': {'version': '1.0'},
+                                    'test_proj3': {'version': '3.0'}}
+
+        expected = {'test_proj1': {'summary': 'Summary for project 1',
+                                   'installed_version': '1.0',
+                                  'latest_version': '1.5'},
+                    'test_proj2': {'summary': 'Summary for project 2'},
+                    'test_proj3': {'summary': 'Summary for project 3',
+                                   'installed_version': '3.0',
+                                   'latest_version': '3.5'}}
         result = pip2.commands.search.search('test')
-        
+
         self.tear_down(result, expected)
-          
+
     def tear_down(self, result, expected):
         try:
             assert result == expected
@@ -68,7 +72,7 @@ class TestSearchAPI():
 
 
 @mock.patch.object(pip2.util, 'getTerminalSize')
-@mock.patch.object(pip2.commands.search, 'search')    
+@mock.patch.object(pip2.commands.search, 'search')
 class TestSearchCLI():
     default_term_size = 80
     term_size = default_term_size
@@ -77,128 +81,132 @@ class TestSearchCLI():
     buffer = len(cli_sep)
     sum_len = term_size - name_len - buffer - 1
     args = mock.Mock()
-    args.package = "pkgPlaceholder"
+    args.package = 'pkgPlaceholder'
     originalOut = sys.stdout
-    
+
     def setup(self):
-        sys.stdout = result = StringIO() 
+        sys.stdout = result = StringIO()
         return result
-        
+
     def test_basic_display_no_results(self, mock_search, mock_getTerminalSize):
         result = self.setup()
-        self.args.package = "nonexistantPackage"
+        self.args.package = 'nonexistantPackage'
         mock_getTerminalSize.return_value = (self.term_size, None)
         mock_search.return_value = {}
-        expected = "Search returned no results...\n"
+        expected = 'Search returned no results...\n'
         pip2.cli_wrapper.search(self.args)
         self.tear_down(result.getvalue(), expected)
-        
+
     def test_basic_display_name_short(self, mock_search, mock_getTerminalSize):
         result = self.setup()
-        self.args.package = "shortPackage"
+        self.args.package = 'shortPackage'
         mock_getTerminalSize.return_value = (self.term_size, None)
-        mock_search.return_value = {self.args.package:{'summary':'summary placeholder'}}
+        mock_search.return_value = {self.args.package: {'summary':
+                                                        'summary placeholder'}}
         expected = self.args.package
-        expected += (" "*(self.name_len - len(expected)) + self.cli_sep + 
-                     "summary placeholder\n")
+        expected += (' ' * (self.name_len - len(expected)) + self.cli_sep +
+                     'summary placeholder\n')
         pip2.cli_wrapper.search(self.args)
         self.tear_down(result.getvalue(), expected)
-         
+
     def test_basic_display_name_long(self, mock_search, mock_getTerminalSize):
         result = self.setup()
-        self.args.package = "thisIsAVeryLongPackageThatCantDisplayFully"
+        self.args.package = 'thisIsAVeryLongPackageThatCantDisplayFully'
         mock_getTerminalSize.return_value = (self.term_size, None)
-        mock_search.return_value = {self.args.package:{'summary':'summary placeholder'}}
-        expected = (self.args.package[:self.name_len] + self.cli_sep + 
-                    "summary placeholder\n")
+        mock_search.return_value = {self.args.package: {'summary':
+                                                        'summary placeholder'}}
+        expected = (self.args.package[: self.name_len] + self.cli_sep +
+                    'summary placeholder\n')
         pip2.cli_wrapper.search(self.args)
         self.tear_down(result.getvalue(), expected)
-        
-    def test_basic_display_sum_single_line(self, mock_search, mock_getTerminalSize):
+
+    def test_basic_display_sum_single_line(self, mock_search,
+                                           mock_getTerminalSize):
         result = self.setup()
-        self.args.package = "pkgPlaceholder"
+        self.args.package = 'pkgPlaceholder'
         mock_getTerminalSize.return_value = (self.term_size, None)
-        desc = 'X'*(self.sum_len)
-        mock_search.return_value = {self.args.package:{'summary':desc}}
-        expected = (self.args.package + ' '*(self.name_len - len(self.args.package)) + 
-                    self.cli_sep + desc + '\n')        
+        desc = 'X' * (self.sum_len)
+        mock_search.return_value = {self.args.package: {'summary': desc}}
+        expected = (self.args.package + ' ' * (self.name_len -
+                    len(self.args.package)) + self.cli_sep + desc + '\n')
         pip2.cli_wrapper.search(self.args)
         self.tear_down(result.getvalue(), expected)
-           
-    def test_basic_display_sum_word_wrap(self, mock_search, mock_getTerminalSize):
+
+    def test_basic_display_sum_word_wrap(self, mock_search,
+                                         mock_getTerminalSize):
         result = self.setup()
-        self.args.package = "pkgPlaceholder"
+        self.args.package = 'pkgPlaceholder'
         mock_getTerminalSize.return_value = (self.term_size, None)
-        desc = 'X'*int(self.sum_len*1.5)
-        mock_search.return_value = {self.args.package:{'summary':desc}}
-        desc_ln1 = desc[:self.sum_len]
+        desc = 'X' * int(self.sum_len * 1.5)
+        mock_search.return_value = {self.args.package: {'summary': desc}}
+        desc_ln1 = desc[: self.sum_len]
         desc_ln2 = desc[len(desc_ln1):]
-        expected = (self.args.package + ' '*(self.name_len - len(self.args.package)) + 
-                    self.cli_sep + desc_ln1 + '\n' + 
-                    ' '*(self.name_len + self.buffer) + desc_ln2 + '\n')
+        expected = (self.args.package + ' ' * (self.name_len -
+                    len(self.args.package)) + self.cli_sep + desc_ln1 + '\n' +
+                    ' ' * (self.name_len + self.buffer) + desc_ln2 + '\n')
         pip2.cli_wrapper.search(self.args)
         self.tear_down(result.getvalue(), expected)
-    
+
     # incomplete test
     def test_basic_display_matches(self, mock_search, mock_getTerminalSize):
         result = self.setup()
-        self.args.package = "pkgPlaceholder"
+        self.args.package = 'pkgPlaceholder'
         mock_getTerminalSize.return_value = (self.term_size, None)
         installed = '1.0'
         latest = '1.5'
-        desc = 'X'*self.sum_len
-        mock_search.return_value = {self.args.package:{'summary':desc, 
-                                    'installed_version':installed, 
-                                    'latest_version':latest}}
-        expected = (self.args.package + ' '*(self.name_len - len(self.args.package)) + 
-                    self.cli_sep + desc + '\n\tINSTALLED: ' + installed + 
-                    '\n\tLATEST   : ' + latest + '\n')
+        desc = 'X' * self.sum_len
+        mock_search.return_value = {self.args.package: {'summary': desc,
+                                    'installed_version': installed,
+                                    'latest_version': latest}}
+        expected = (self.args.package + ' ' * (self.name_len -
+                    len(self.args.package)) + self.cli_sep + desc +
+                    '\n\tINSTALLED: ' + installed + '\n\tLATEST   : ' +
+                    latest + '\n')
         pip2.cli_wrapper.search(self.args)
         self.tear_down(result.getvalue(), expected)
-    
-    def test_basic_display_small_terminal_size(self, mock_search, mock_getTerminalSize):
+
+    def test_basic_display_small_terminal_size(self, mock_search,
+                                               mock_getTerminalSize):
         self.term_size = 60
         self.sum_len = self.term_size - self.name_len - self.buffer - 1
         self._run_all_package_info_tests()
         self.term_size = self.default_term_size
-            
-    def test_basic_display_large_terminal_size(self, mock_search, mock_getTerminalSize):
+
+    def test_basic_display_large_terminal_size(self, mock_search,
+                                               mock_getTerminalSize):
         self.term_size = 180
         self.sum_len = self.term_size - self.name_len - self.buffer - 1
         self._run_all_package_info_tests()
         self.term_size = self.default_term_size
-           
+
     def _run_all_package_info_tests(self):
-        self.test_basic_display_no_results()        
+        self.test_basic_display_no_results()
         self.test_basic_display_name_short()
         self.test_basic_display_name_long()
         self.test_basic_display_sum_single_line()
         self.test_basic_display_sum_word_wrap()
         self.test_basic_display_matches()
-      
+
     def tear_down(self, result, expected):
         try:
             assert result == expected
         except AssertionError:
             result = result.replace('\n', '\\n')
             expected = expected.replace('\n', '\\n')
-            # tests with non-default terminal sizes are system level, so they 
-            # call multiple subtests we want to know which specific subtest 
+            # tests with non-default terminal sizes are system level, so they
+            # call multiple subtests we want to know which specific subtest
             # failed inside the parent
             if self.term_size == self.default_term_size:
-                parent = "No Parent"
+                parent = 'No Parent'
             else:
-                parent = inspect.stack()[4][3]    
-            output = ("\n\nTEST FAILED" + 
-                      "\nFunction  : {0}".format(inspect.stack()[1][3]) +
-                      "\nParent    : {0}".format(parent) + 
-                      "\nTerm width: {0}".format(self.term_size) + 
-                      "\nResult    :\n{0}\n".format(result) + 
-                      "\nExpected  :\n{0}".format(expected))
+                parent = inspect.stack()[4][3]
+            output = ('\n\nTEST FAILED' +
+                      '\nFunction  : {0}'.format(inspect.stack()[1][3]) +
+                      '\nParent    : {0}'.format(parent) +
+                      '\nTerm width: {0}'.format(self.term_size) +
+                      '\nResult    : \n{0}\n'.format(result) +
+                      '\nExpected  : \n{0}'.format(expected))
             print(output, file=sys.stderr)
             raise
         finally:
             sys.stdout = self.originalOut
-
-
-    


### PR DESCRIPTION
Cleaned up freeze, freeze tests, search, search tests, and cli_wrapper so that they conform to Pep8 standards. Also standardized all quotes to single quotes unless double are needed. Finished test_basic_display_matches in search_tests. Search now searches a package's summary and name instead of just name. Search also displays latest package version number in results.
