### PR TITLE
Import non-stdlib packages first if installed

### DIFF
--- a/pip2/compat.py
+++ b/pip2/compat.py
@@ -1,26 +1,27 @@
 """Stuff that differs in different Python versions."""
 
-import sys
-
-
-if sys.version_info >= (3, 3):
-    import packaging
-    import packaging.database
-    import packaging.install
-    import packaging.pypi
-    try:
-        import unittest.mock as mock
-    except ImportError:
-        # Mock isn't needed for normal functionality, so don't worry if it
-        # can't be imported here; the tests will complain if they need it
-        pass
-else:
+# Try importing the non-stdlib version of the library (distutils2) first to
+# allow newer versions to override older functionality in the standard library.
+try:
     import distutils2 as packaging
     import distutils2.database
     import distutils2.install
     import distutils2.pypi
+except ImportError:
+    # Available in the standard library in Python 3.3+
+    import packaging
+    import packaging.database
+    import packaging.install
+    import packaging.pypi
+
+# Try importing the non-stdlib version of mock first to allow newer versions to
+# override older functionality in the standard library.
+try:
+    import mock
+except ImportError:
     try:
-        import mock
+        # Available in the standard library in Python 3.3+
+        import unittest.mock as mock
     except ImportError:
         # Mock isn't needed for normal functionality, so don't worry if it
         # can't be imported here; the tests will complain if they need it

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py32,py33
+envlist = py32,py33,py33-3rd-party-libs
 
 [testenv:py32]
 commands =
@@ -19,3 +19,14 @@ commands =
 deps =
     nose
     sphinx
+
+[testenv:py33-3rd-party-libs]
+basepython = python3.3
+commands =
+    nosetests {posargs}
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
+deps =
+    nose
+    sphinx
+    mock
+    http://hg.python.org/distutils2/archive/python3.tar.bz2


### PR DESCRIPTION
Modify compat.py to always use the distutils2/packaging and mock
libraries that are outside of the standard library if they are
available.  This allows newer versions of these libraries to be
installed/used to override outdated versions in the standard library.
