### PR TITLE
Add API documentation for the commands

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import sys, os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration -----------------------------------------------------
 
@@ -26,7 +26,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = ['sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/dev/api/index.rst
+++ b/docs/dev/api/index.rst
@@ -1,0 +1,22 @@
+API Reference
+=============
+
+Freeze
+------
+
+.. autofunction:: pip2.commands.freeze.freeze
+
+Install
+-------
+
+.. autofunction:: pip2.commands.install.install
+
+Search
+------
+
+.. autofunction:: pip2.commands.search.search
+
+Uninstall
+---------
+
+.. autofunction:: pip2.commands.uninstall.uninstall

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -1,0 +1,8 @@
+Developer's Guide
+=================
+
+Table of contents:
+
+.. toctree::
+   contributing
+   api/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,4 +7,4 @@ Developer Guide
 .. toctree::
    :maxdepth: 2
 
-   dev/contributing
+   dev/index

--- a/pip2/commands/freeze.py
+++ b/pip2/commands/freeze.py
@@ -1,14 +1,29 @@
-"""
-Returns a dictionary containing all installed packages.
+"""The freeze command.
 
-return: A dictionary, key is package name value is a dictionary with
-        information about package.
+This module implements the freeze command with an interface that matches the
+command line usage.
+
 """
 
 from pip2.compat import packaging
 
 
 def freeze():
+    """Get a list of installed projects.
+
+    Returns a dictionary where the keys are project names and the values are
+    dictionaries with the following keys and values:
+
+    * `'version'` - a string containing the project's version.
+
+    For example, the return value may look like this::
+
+        {   'TowelStuff': {'version': '0.1.1'},
+            'pip2': {'version': '1.0'}}
+
+    :rtype: dictionary
+
+    """
     results = list(packaging.database.get_distributions(use_egg_info=True))
     installed = dict()
     for dist in results:

--- a/pip2/commands/install.py
+++ b/pip2/commands/install.py
@@ -1,6 +1,8 @@
-"""
-Installs a package and returns a dictionary containing which packages
-were installed successfully or unsuccessfully.
+"""The install command.
+
+This module implements the install command with an interface that matches the
+command line usage.
+
 """
 
 import os
@@ -8,20 +10,40 @@ import os
 from pip2.compat import packaging
 
 
-def install(package_list):
+def install(project_list):
+    """Install a list of projects.
+
+    Note that project dependencies are not yet detected and installed.
+
+    Returns a dictionary with the following keys and values:
+
+    * `'installed'` - a list of strings containing the projects that were
+      successfully installed.
+
+    * `'failed'` - a list of strings containing the projects that failed to
+      install.
+
+    :param project_list: the projects to install.  May be names of projects on
+                         the Python Package Index (PyPI) or paths to local
+                         directories and archives (.zip, .tar.gz, .tar.bz2,
+                         .tgz, or .tar).
+    :type project_list: iterable of strings
+    :rtype: dictionary
+
+    """
     result = {'installed': [], 'failed': []}
 
-    for package in package_list:
+    for project in project_list:
         success = False
 
-        if os.path.exists(package):
-            success = packaging.install.install_local_project(package)
+        if os.path.exists(project):
+            success = packaging.install.install_local_project(project)
         else:
-            success = packaging.install.install(package)
+            success = packaging.install.install(project)
 
         if success:
-            result['installed'].append(package)
+            result['installed'].append(project)
         else:
-            result['failed'].append(package)
+            result['failed'].append(project)
 
     return result

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -1,25 +1,45 @@
-"""
-Searches the PYPIs for packages based off of
-the 'package' parameter, the default is the http://python.org/pypi index
+"""The search command.
 
-package: search query (usually package name) as string.
+This module implements the search command with an interface that matches the
+command line usage.
 
-return: A dictionary of search results. Key is package name value is dictionary
-        containing information about the package.
 """
 
 import pip2.commands.freeze
 from pip2.compat import packaging
 
 
-def search(package):
-    """
-    Searches the PYPIs for packages based off of
-    the 'package' parameter, the default is the http://python.org/pypi index
+def search(query):
+    """Search projects on the Python Package Index (PyPI).
+
+    Searches the `name` and `summary` fields for projects that match `query`.
+
+    Returns a dictionary containing the search results.  The keys are project
+    names and the values are dictionaries with the following keys and values:
+
+    * `'summary'` - a string containing the project's summary.
+
+    * `'installed_version'` (only present if the project is installed) - a
+      string containing the version of the project currently installed.
+
+    * `'latest_version'` (only present if the project is installed) - a string
+      containing the latest version of the project available on the index.
+
+    For example, the return value may look like this::
+
+        {   'TowelStuff': {   'installed_version': '0.1.1',
+                              'latest_version': '0.1.1',
+                              'summary': 'Useful towel-related stuff.'},
+            'towel': {'summary': 'Keeping you DRY since 2010'}}
+
+    :param query: the search query.
+    :type query: string
+    :rtype: dictionary
+
     """
     results = dict()
     client = packaging.pypi.xmlrpc.Client()
-    projects = client.search_projects(name=package, summary=package)
+    projects = client.search_projects(name=query, summary=query)
     installed = pip2.commands.freeze.freeze()
 
     for project in projects:

--- a/pip2/commands/uninstall.py
+++ b/pip2/commands/uninstall.py
@@ -1,18 +1,35 @@
-"""
-Uninstalls a package and returns a dictionary containing which packages
-were uninstalled successfully or unsuccessfully.
+"""The uninstall command.
+
+This module implements the uninstall command with an interface that matches the
+command line usage.
+
 """
 
 from pip2.compat import packaging
 
 
-def uninstall(package_list):
+def uninstall(project_list):
+    """Uninstall a list of projects.
+
+    Returns a dictionary with the following keys and values:
+
+    * `'uninstalled'` - a list of strings containing the names of the projects
+      that were successfully uninstalled.
+
+    * `'failed'` - a list of strings containing the names of the projects that
+      failed to uninstall.
+
+    :param project_list: the names of the projects to uninstall.
+    :type project_list: iterable of strings
+    :rtype: dictionary
+
+    """
     result = {'uninstalled': [], 'failed': []}
 
-    for package in package_list:
-        if packaging.install.remove(package):
-            result['uninstalled'].append(package)
+    for project in project_list:
+        if packaging.install.remove(project):
+            result['uninstalled'].append(project)
         else:
-            result['failed'].append(package)
+            result['failed'].append(project)
 
     return result


### PR DESCRIPTION
Added Sphinx-style docstrings to all the commands in pip2.commands.\* and added an "API Reference" section to the documentation. Once merged, the new API Reference section should appear [here](http://pip2.readthedocs.org/en/latest/dev/api/).
