### PR TITLE
Help functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Projects can be installed from the `Python Packaging Index (PyPI)`_::
 
     $ pip2 install TowelStuff sample-distutils2-project
     [...]
-    Successfully installed TowelStuff sample-distutils2-project.
+    Successfully installed TowelStuff, sample-distutils2-project.
 
 .. _Python Packaging Index (PyPI): http://pypi.python.org/pypi
 

--- a/pip2/__init__.py
+++ b/pip2/__init__.py
@@ -15,9 +15,11 @@ def main():
     logging.basicConfig(format='%(message)s', level=logging.INFO)
 
     parser = pip2.pip_parser.create_parser()
-
     args = parser.parse_args()
-    args.func(args)
+    try:
+        args.func(args)
+    except AttributeError:
+        parser.print_help()
 
 if __name__ == '__main__':
     main()

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -21,10 +21,10 @@ def install(args):
     result = pip2.commands.install.install(args.package_list)
 
     if result['installed'] != []:
-        successful = ' '.join(map(str, result['installed']))
+        successful = ', '.join(map(str, result['installed']))
         print('Successfully installed {0}.'.format(successful))
     if result['failed'] != []:
-        failed = ' '.join(map(str, result['failed']))
+        failed = ', '.join(map(str, result['failed']))
         print('Failed to install {0}.'.format(failed))
 
     return
@@ -34,10 +34,10 @@ def uninstall(args):
     result = pip2.commands.uninstall.uninstall(args.package_list)
 
     if result['uninstalled'] != []:
-        successful = ' '.join(map(str, result['uninstalled']))
+        successful = ', '.join(map(str, result['uninstalled']))
         print('Successfully uninstalled {0}.'.format(successful))
     if result['failed'] != []:
-        failed = ' '.join(map(str, result['failed']))
+        failed = ', '.join(map(str, result['failed']))
         print('Failed to uninstall {0}.'.format(failed))
 
     return

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -18,7 +18,7 @@ import pip2.util
 
 
 def install(args):
-    result = pip2.commands.install.install(args.package_list)
+    result = pip2.commands.install.install(args.project_list)
 
     if result['installed'] != []:
         successful = ', '.join(map(str, result['installed']))
@@ -31,7 +31,7 @@ def install(args):
 
 
 def uninstall(args):
-    result = pip2.commands.uninstall.uninstall(args.package_list)
+    result = pip2.commands.uninstall.uninstall(args.project_list)
 
     if result['uninstalled'] != []:
         successful = ', '.join(map(str, result['uninstalled']))
@@ -53,7 +53,7 @@ def freeze(args):
 
 
 def search(args):
-    results = pip2.commands.search.search(args.package)
+    results = pip2.commands.search.search(args.project)
     if results == {}:
         print('Search returned no results...')
         return
@@ -76,7 +76,7 @@ def search(args):
         try:
             line = '{0:<{1}}{2}{3}'.format(res, name_len, sep, summary.pop(0))
             line = line[: (term_width - 1)]
-        # international packages have encoding issues, we just skip and move on
+        # international projects have encoding issues, we just skip and move on
         except SystemError:
             print('SKIPPING RESULT: CANNOT DISPLAY UNKNOWN CHARACTERS')
             continue
@@ -104,7 +104,7 @@ def _search_safe_print(string, name=None):
         print(string)
     except UnicodeError:
         if name:
-            # try and print just the package name incase the summary is causing
+            # try and print just the project name incase the summary is causing
             # the exception
             try:
                 print('{0:<{1}}{2}'.format(name, name_len, sep) +

--- a/pip2/pip_parser.py
+++ b/pip2/pip_parser.py
@@ -8,22 +8,22 @@ import pip2.cli_wrapper
 
 
 def create_parser():
-    parser = argparse.ArgumentParser(prog='pip2')
+    parser = argparse.ArgumentParser(prog='pip2', description="Manage python projects")
     subparsers = parser.add_subparsers()
 
-    parser_install = subparsers.add_parser('install', help='- Install a package or list of packages')
-    parser_install.add_argument('package_list', nargs='+', help='- Package or list of packages to install')
+    parser_install = subparsers.add_parser('install', help='- Install a project or list of projects')
+    parser_install.add_argument('project_list', nargs='+', help='- project or list of projects to install')
     parser_install.set_defaults(func=pip2.cli_wrapper.install)
 
-    parser_uninstall = subparsers.add_parser('uninstall', help='- Uninstall a package or list of packages')
-    parser_uninstall.add_argument('package_list', nargs='+', help='- Package or list of packages to uninstall')
+    parser_uninstall = subparsers.add_parser('uninstall', help='- Uninstall a project or list of projects')
+    parser_uninstall.add_argument('project_list', nargs='+', help='- project or list of projects to uninstall')
     parser_uninstall.set_defaults(func=pip2.cli_wrapper.uninstall)
 
-    parser_freeze = subparsers.add_parser('freeze', help='- Display locally installed packages')
+    parser_freeze = subparsers.add_parser('freeze', help='- Display locally installed projects')
     parser_freeze.set_defaults(func=pip2.cli_wrapper.freeze)
 
-    parser_search = subparsers.add_parser('search', help='- Search for a package on PyPi')
-    parser_search.add_argument('package')
+    parser_search = subparsers.add_parser('search', help='- Search for a project on PyPI')
+    parser_search.add_argument('project')
     parser_search.set_defaults(func=pip2.cli_wrapper.search)
 
     return parser

--- a/pip2/pip_parser.py
+++ b/pip2/pip_parser.py
@@ -11,18 +11,18 @@ def create_parser():
     parser = argparse.ArgumentParser(prog='pip2')
     subparsers = parser.add_subparsers()
 
-    parser_install = subparsers.add_parser('install')
-    parser_install.add_argument('package_list', nargs='+')
+    parser_install = subparsers.add_parser('install', help='- Install a package or list of packages')
+    parser_install.add_argument('package_list', nargs='+', help='- Package or list of packages to install')
     parser_install.set_defaults(func=pip2.cli_wrapper.install)
 
-    parser_uninstall = subparsers.add_parser('uninstall')
-    parser_uninstall.add_argument('package_list', nargs='+')
+    parser_uninstall = subparsers.add_parser('uninstall', help='- Uninstall a package or list of packages')
+    parser_uninstall.add_argument('package_list', nargs='+', help='- Package or list of packages to uninstall')
     parser_uninstall.set_defaults(func=pip2.cli_wrapper.uninstall)
 
-    parser_freeze = subparsers.add_parser('freeze')
+    parser_freeze = subparsers.add_parser('freeze', help='- Display locally installed packages')
     parser_freeze.set_defaults(func=pip2.cli_wrapper.freeze)
 
-    parser_search = subparsers.add_parser('search')
+    parser_search = subparsers.add_parser('search', help='- Search for a package on PyPi')
     parser_search.add_argument('package')
     parser_search.set_defaults(func=pip2.cli_wrapper.search)
 

--- a/pip2/util.py
+++ b/pip2/util.py
@@ -5,6 +5,7 @@ Various utilities used in the commands
 # TODO: Document what each function does and its return value. Difficult to
 # understand some of these.
 
+
 def getTerminalSize():
     import platform
     current_os = platform.system()

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -13,19 +13,19 @@ class TestFreezeAPI():
     def test_basic_freeze(self, mock_gen):
         # create the distributions that the gen will return
         dis1 = mock.Mock()
-        dis1.name = 'test_package1'
+        dis1.name = 'test_project1'
         dis1.version = '1.0'
         dis2 = mock.Mock()
-        dis2.name = 'test_package2'
+        dis2.name = 'test_project2'
         dis2.version = '2.0'
         dis3 = mock.Mock()
-        dis3.name = 'test_package3'
+        dis3.name = 'test_project3'
         dis3.version = '3.0'
 
         # get_distributions gen returns a iterator over distributions objects
         mock_gen.return_value = iter([dis1, dis2, dis3])
-        expected = {'test_package1': {'version': '1.0'}, 'test_package2':
-                    {'version': '2.0'}, 'test_package3': {'version': '3.0'}}
+        expected = {'test_project1': {'version': '1.0'}, 'test_project2':
+                    {'version': '2.0'}, 'test_project3': {'version': '3.0'}}
         # run the command
         result = pip2.commands.freeze.freeze()
         try:
@@ -48,12 +48,12 @@ class TestFreezeCLI():
     def test_basic_freeze(self, mock_func):
         args = mock.Mock()
         result = self.setup()
-        mock_func.return_value = {'test_package1': {'version': '1.0'},
-                                  'test_package2': {'version': '2.0'},
-                                  'test_package3': {'version': '3.0'}}
+        mock_func.return_value = {'test_project1': {'version': '1.0'},
+                                  'test_project2': {'version': '2.0'},
+                                  'test_project3': {'version': '3.0'}}
         pip2.cli_wrapper.freeze(args)
-        expected = 'test_package1==1.0\ntest_package2==2.0\n' + \
-                   'test_package3==3.0\n'
+        expected = 'test_project1==1.0\ntest_project2==2.0\n' + \
+                   'test_project3==3.0\n'
         self.tear_down(result.getvalue(), expected)
 
     def tear_down(self, result, expected):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8,33 +8,33 @@ from pip2.compat import packaging
 @mock.patch.object(packaging.install, 'install')
 class TestInstallAPI():
 
-    def test_install_single_package(self, mock_install):
+    def test_install_single_project(self, mock_install):
         mock_install.return_value = True
-        expected = ['test_package1']
+        expected = ['test_project1']
         result = pip2.commands.install.install(expected)
 
         assert result['installed'] == expected
         assert result['failed'] == []
 
-    def test_install_multiple_packages(self, mock_install):
+    def test_install_multiple_projects(self, mock_install):
         mock_install.return_value = True
-        expected = ['test_package1', 'test_package2', 'test_package3']
+        expected = ['test_project1', 'test_project2', 'test_project3']
         result = pip2.commands.install.install(expected)
 
         assert result['installed'] == expected
         assert result['failed'] == []
 
-    def test_install_fail_single_package(self, mock_install):
+    def test_install_fail_single_project(self, mock_install):
         mock_install.return_value = False
-        expected = ['failing_package']
+        expected = ['failing_project']
         result = pip2.commands.install.install(expected)
 
         assert result['installed'] == []
         assert result['failed'] == expected
 
-    def test_install_fail_multiple_packages(self, mock_install):
+    def test_install_fail_multiple_projects(self, mock_install):
         mock_install.return_value = False
-        expected = ['test_package1', 'test_package2']
+        expected = ['test_project1', 'test_project2']
         result = pip2.commands.install.install(expected)
 
         assert result['installed'] == []
@@ -55,15 +55,15 @@ class TestInstallAPI():
         assert mock_install.called == True
 
     def test_install_mixed_results(self, mock_install):
-        # The current expected behavior is to allow some packages to be
-        # installed even if there other packages fail to install.  In the
+        # The current expected behavior is to allow some projects to be
+        # installed even if there other projects fail to install.  In the
         # future, it will probably be all or nothing.  See issue #51 for more
         # details.
 
         returns = [True, False]
         mock_install.side_effect = lambda *args: returns.pop(0)
-        successes = ['a-real-package']
-        failures = ['not-a-package']
+        successes = ['a-real-project']
+        failures = ['not-a-project']
         result = pip2.commands.install.install(successes + failures)
 
         assert result['installed'] == successes
@@ -73,14 +73,14 @@ class TestInstallAPI():
 @mock.patch.object(packaging.install, 'install')
 class TestInstallCLI():
 
-    def test_install_single_package(self, mock_func):
+    def test_install_single_project(self, mock_func):
         pass
 
-    def test_install_multiple_packages(self, mock_install):
+    def test_install_multiple_projects(self, mock_install):
         pass
 
-    def test_install_fail_single_package(self, mock_install):
+    def test_install_fail_single_project(self, mock_install):
         pass
 
-    def test_install_fail_multiple_packages(self, mock_install):
+    def test_install_fail_multiple_projects(self, mock_install):
         pass

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -83,7 +83,7 @@ class TestSearchCLI():
     sep_len = len(sep)
     sum_len = term_width - name_len - sep_len - 1
     args = mock.Mock()
-    args.package = 'pkgPlaceholder'
+    args.project = 'pkgPlaceholder'
     originalOut = sys.stdout
 
     def setup(self):
@@ -92,7 +92,7 @@ class TestSearchCLI():
 
     def test_basic_display_no_results(self, mock_search, mock_getTerminalSize):
         result = self.setup()
-        self.args.package = 'nonexistantPackage'
+        self.args.project = 'nonexistantproject'
         mock_getTerminalSize.return_value = (self.term_width, None)
         mock_search.return_value = {}
         expected = 'Search returned no results...\n'
@@ -101,20 +101,20 @@ class TestSearchCLI():
 
     def test_basic_display_name_short(self, mock_search, mock_getTerminalSize):
         result = self.setup()
-        self.args.package = 'shortPackage'
+        self.args.project = 'shortproject'
         mock_getTerminalSize.return_value = (self.term_width, None)
-        mock_search.return_value = {self.args.package: {'summary': 'sum'}}
-        expected = self.args.package
+        mock_search.return_value = {self.args.project: {'summary': 'sum'}}
+        expected = self.args.project
         expected += ' ' * (self.name_len - len(expected)) + self.sep + 'sum\n'
         pip2.cli_wrapper.search(self.args)
         self.tear_down(result.getvalue(), expected)
 
     def test_basic_display_name_long(self, mock_search, mock_getTerminalSize):
         result = self.setup()
-        self.args.package = 'thisIsAVeryLongPackageThatCantDisplayFully'
+        self.args.project = 'thisIsAVeryLongprojectThatCantDisplayFully'
         mock_getTerminalSize.return_value = (self.term_width, None)
-        mock_search.return_value = {self.args.package: {'summary': 'sum'}}
-        expected = self.args.package + self.sep + 'sum'
+        mock_search.return_value = {self.args.project: {'summary': 'sum'}}
+        expected = self.args.project + self.sep + 'sum'
         expected = expected[: (self.sum_len + self.name_len +
                                self.sep_len)] + '\n'
         pip2.cli_wrapper.search(self.args)
@@ -123,42 +123,42 @@ class TestSearchCLI():
     def test_basic_display_sum_single_line(self, mock_search,
                                            mock_getTerminalSize):
         result = self.setup()
-        self.args.package = 'pkgPlaceholder'
+        self.args.project = 'pkgPlaceholder'
         mock_getTerminalSize.return_value = (self.term_width, None)
         desc = 'X' * (self.sum_len)
-        mock_search.return_value = {self.args.package: {'summary': desc}}
-        expected = (self.args.package + ' ' * (self.name_len -
-                    len(self.args.package)) + self.sep + desc + '\n')
+        mock_search.return_value = {self.args.project: {'summary': desc}}
+        expected = (self.args.project + ' ' * (self.name_len -
+                    len(self.args.project)) + self.sep + desc + '\n')
         pip2.cli_wrapper.search(self.args)
         self.tear_down(result.getvalue(), expected)
 
     def test_basic_display_sum_word_wrap(self, mock_search,
                                          mock_getTerminalSize):
         result = self.setup()
-        self.args.package = 'pkgPlaceholder'
+        self.args.project = 'pkgPlaceholder'
         mock_getTerminalSize.return_value = (self.term_width, None)
         desc = 'X' * int(self.sum_len * 1.5)
-        mock_search.return_value = {self.args.package: {'summary': desc}}
+        mock_search.return_value = {self.args.project: {'summary': desc}}
         desc_ln1 = desc[: self.sum_len]
         desc_ln2 = desc[len(desc_ln1):]
-        expected = (self.args.package + ' ' * (self.name_len -
-                    len(self.args.package)) + self.sep + desc_ln1 + '\n' +
+        expected = (self.args.project + ' ' * (self.name_len -
+                    len(self.args.project)) + self.sep + desc_ln1 + '\n' +
                     ' ' * (self.name_len + self.sep_len) + desc_ln2 + '\n')
         pip2.cli_wrapper.search(self.args)
         self.tear_down(result.getvalue(), expected)
 
     def test_basic_display_matches(self, mock_search, mock_getTerminalSize):
         result = self.setup()
-        self.args.package = 'pkgPlaceholder'
+        self.args.project = 'pkgPlaceholder'
         mock_getTerminalSize.return_value = (self.term_width, None)
         installed = '1.0'
         latest = '1.5'
         desc = 'X' * self.sum_len
-        mock_search.return_value = {self.args.package: {'summary': desc,
+        mock_search.return_value = {self.args.project: {'summary': desc,
                                     'installed_version': installed,
                                     'latest_version': latest}}
-        expected = (self.args.package + ' ' * (self.name_len -
-                    len(self.args.package)) + self.sep + desc +
+        expected = (self.args.project + ' ' * (self.name_len -
+                    len(self.args.project)) + self.sep + desc +
                     '\n\tINSTALLED: ' + installed + '\n\tLATEST   : ' +
                     latest + '\n')
         pip2.cli_wrapper.search(self.args)
@@ -180,10 +180,10 @@ class TestSearchCLI():
             else:
                 width_used = self.min_term_width
             self.sum_len = width_used - self.name_len - self.sep_len - 1
-            self._run_all_package_tests()
+            self._run_all_project_tests()
             self.term_width = self.default_term_width
 
-    def _run_all_package_tests(self):
+    def _run_all_project_tests(self):
         self.test_basic_display_no_results()
         self.test_basic_display_name_short()
         self.test_basic_display_name_long()

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -10,33 +10,33 @@ from pip2.compat import packaging
 @mock.patch.object(packaging.install, 'remove')
 class TestUninstallAPI():
 
-    def test_uninstall_single_package(self, mock_func):
+    def test_uninstall_single_project(self, mock_func):
         mock_func.return_value = True
-        expected = ['test_package1']
+        expected = ['test_project1']
         result = pip2.commands.uninstall.uninstall(expected)
 
         assert result['uninstalled'] == expected
         assert result['failed'] == []
 
-    def test_uninstall_multiple_packages(self, mock_func):
+    def test_uninstall_multiple_projects(self, mock_func):
         mock_func.return_value = True
-        expected = ['test_package1', 'test_package2', 'test_package3']
+        expected = ['test_project1', 'test_project2', 'test_project3']
         result = pip2.commands.uninstall.uninstall(expected)
 
         assert result['uninstalled'] == expected
         assert result['failed'] == []
 
-    def test_uninstall_fail_single_package(self, mock_func):
+    def test_uninstall_fail_single_project(self, mock_func):
         mock_func.return_value = False
-        expected = ['failing_package1']
+        expected = ['failing_project1']
         result = pip2.commands.uninstall.uninstall(expected)
 
         assert result['uninstalled'] == []
         assert result['failed'] == expected
 
-    def test_uninstall_fail_multiple_packages(self, mock_func):
+    def test_uninstall_fail_multiple_projects(self, mock_func):
         mock_func.return_value = False
-        expected = ['failing_package1', 'failing_package2']
+        expected = ['failing_project1', 'failing_project2']
         result = pip2.commands.uninstall.uninstall(expected)
 
         assert result['uninstalled'] == []
@@ -46,14 +46,14 @@ class TestUninstallAPI():
 @mock.patch.object(packaging.install, 'remove')
 class TestUninstallCLI():
 
-    def test_uninstall_single_package(self, mock_func):
+    def test_uninstall_single_project(self, mock_func):
         pass
 
-    def test_uninstall_multiple_packages(self, mock_func):
+    def test_uninstall_multiple_projects(self, mock_func):
         pass
 
-    def test_uninstall_fail_single_package(self, mock_func):
+    def test_uninstall_fail_single_project(self, mock_func):
         pass
 
-    def test_uninstall_fail_multiple_packages(self, mock_func):
+    def test_uninstall_fail_multiple_projects(self, mock_func):
         pass


### PR DESCRIPTION
pip2 now prints usage/help for each command and when called without any arguments.
- Inserted help messages into each argparse subcommand
- Caught attribute error when pip2 called without arguments and print usage
- Changed various references to "package" to "project"
- Updated readme to show that package names are now separated by commas on output
