### PR TITLE
Attempt to fix readthedocs.org build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,12 @@ version = '0.0.1.dev1'
 install_requires = []
 
 if sys.version_info < (3, 3):
-    # Distutils2 on PyPI doesn't work for Python 3, so we aren't listing it as
-    # a dependency yet (see Github issue 45)
-    #install_requires.append('distutils2')
-    pass
+    # Distutils2 is required for Python versions prior to 3.3, but there is
+    # currently no Python 3 version on PyPI (see GitHub issue 45). For now,
+    # only depend on distutils2 for Python 2; it needs to be installed manually
+    # for Python 3 (prior to 3.3).
+    if sys.version_info < (3,):
+        install_requires.append('distutils2')
 
 
 setup(name="pip2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
-envlist = py32,py33,py33-3rd-party-libs
+envlist = py32,py33,py33-3rd-party-libs,rtfd
 
 [testenv:py32]
 commands =
     nosetests {posargs}
-    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 deps =
     nose
-    sphinx
     mock
     http://hg.python.org/distutils2/archive/python3.tar.bz2
 
@@ -15,18 +13,22 @@ deps =
 basepython = python3.3
 commands =
     nosetests {posargs}
-    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 deps =
     nose
-    sphinx
 
 [testenv:py33-3rd-party-libs]
 basepython = python3.3
 commands =
     nosetests {posargs}
-    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 deps =
     nose
-    sphinx
     mock
     http://hg.python.org/distutils2/archive/python3.tar.bz2
+
+# Verify the documentation will build for readthedocs.org
+[testenv:rtfd]
+basepython = python2.7
+commands =
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
+deps =
+    sphinx


### PR DESCRIPTION
My last attempt to add API documentation (using the Sphinx autodoc
extension) on readthedocs.org failed because Sphinx needed to import
pip2, but failed because distutils2 wasn't installed.

To fix this, I added 'distutils2' to install_requires in setup.py for
Python 2. I also configured RTFD to install pip2 (which should also pull
in its requirements, i.e. distutils2) before building the documentation.

If this works, the API section on RTFD should display properly once the
documentation is rebuilt.

http://pip2.readthedocs.org/en/latest/dev/api/
