### PR TITLE
Added Logger

### DIFF
--- a/pip2/__init__.py
+++ b/pip2/__init__.py
@@ -6,13 +6,12 @@ Entry point for pip2
 # docs/conf.py
 __version__ = '0.0.1.dev1'
 
-import logging
-
 import pip2.pip_parser
+import pip2.log
 
 
 def main():
-    logging.basicConfig(format='%(message)s', level=logging.INFO)
+    pip2.log.setup_logger()
 
     parser = pip2.pip_parser.create_parser()
     args = parser.parse_args()

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -6,56 +6,63 @@ line.
 
 import sys
 import textwrap
+import logging
 
 import pip2.commands.install
 import pip2.commands.uninstall
 import pip2.commands.freeze
 import pip2.commands.search
 import pip2.util
+from pip2.log import logger
+#assert isinstance(logger, logging.Logger)
 
 
 # TODO: Add options to match pip feature set
 
 
 def install(args):
+    logger.debug('Running install command with args: {0}'.format(args.project_list))
     result = pip2.commands.install.install(args.project_list)
 
     if result['installed'] != []:
         successful = ', '.join(map(str, result['installed']))
-        print('Successfully installed {0}.'.format(successful))
+        logger.info('Successfully installed {0}.'.format(successful))
     if result['failed'] != []:
         failed = ', '.join(map(str, result['failed']))
-        print('Failed to install {0}.'.format(failed))
+        logger.info('Failed to install {0}.'.format(failed))
 
     return
 
 
 def uninstall(args):
+    logger.debug('Running uninstall command with args: {0}'.format(args.project_list))
     result = pip2.commands.uninstall.uninstall(args.project_list)
 
     if result['uninstalled'] != []:
         successful = ', '.join(map(str, result['uninstalled']))
-        print('Successfully uninstalled {0}.'.format(successful))
+        logger.info('Successfully uninstalled {0}.'.format(successful))
     if result['failed'] != []:
         failed = ', '.join(map(str, result['failed']))
-        print('Failed to uninstall {0}.'.format(failed))
+        logger.info('Failed to uninstall {0}.'.format(failed))
 
     return
 
 
 def freeze(args):
+    logger.debug('Running freeze command with args: None'))
     distributions = pip2.commands.freeze.freeze()
     dist_names = list(distributions.keys())
     dist_names.sort()
     for dist_name in dist_names:
-        print(dist_name + '==' + distributions[dist_name]['version'])
+        logger.info(dist_name + '==' + distributions[dist_name]['version'])
     return
 
 
 def search(args):
+    logger.debug('Running search command with args: {0}'.format(args.project))
     results = pip2.commands.search.search(args.project)
     if results == {}:
-        print('Search returned no results...')
+        logger.info('Search returned no results...')
         return
     # when cli_wrapper gets split into multiple files, one for each command
     # these will be global
@@ -77,8 +84,8 @@ def search(args):
             line = '{0:<{1}}{2}{3}'.format(res, name_len, sep, summary.pop(0))
             line = line[: (term_width - 1)]
         # international projects have encoding issues, we just skip and move on
-        except SystemError:
-            print('SKIPPING RESULT: CANNOT DISPLAY UNKNOWN CHARACTERS')
+        except SystemError as e:
+            logger.info('SKIPPING RESULT: CANNOT DISPLAY UNKNOWN CHARACTERS')
             continue
         success = _search_safe_print(line, res)
         if not success:
@@ -90,9 +97,9 @@ def search(args):
                 break
         if ('installed_version' in results[res] and
             'latest_version' in results[res] and success):
-            print('\tINSTALLED: {0}\n\tLATEST   : {1}'.format(
-                  results[res]['installed_version'],
-                  results[res]['latest_version']))
+            logger.info('\tINSTALLED: {0}\n\tLATEST   : {1}'.format(
+                        results[res]['installed_version'],
+                        results[res]['latest_version']))
     return
 
 
@@ -101,18 +108,18 @@ def _search_safe_print(string, name=None):
     sep = ' - '
     name_len = 26
     try:
-        print(string)
+        logger.info(string)
     except UnicodeError:
         if name:
             # try and print just the project name incase the summary is causing
             # the exception
             try:
-                print('{0:<{1}}{2}'.format(name, name_len, sep) +
-                      'CANNOT DISPLAY SUMMARY WITH ' +
-                      '({0}) ENCODING'.format(sys.getdefaultencoding()))
+                logger.info('{0:<{1}}{2}'.format(name, name_len, sep) +
+                            'CANNOT DISPLAY SUMMARY WITH ' +
+                            '({0}) ENCODING'.format(sys.getdefaultencoding()))
             except UnicodeError:
-                print('SKIPPING RESULT: CANNOT DISPLAY WITH ' +
-                      '({0}) ENCODING'.format(sys.getdefaultencoding()))
+                logger.info('SKIPPING RESULT: CANNOT DISPLAY WITH ' +
+                            '({0}) ENCODING'.format(sys.getdefaultencoding()))
                 return False
             else:
                 return True

--- a/pip2/cli_wrapper.py
+++ b/pip2/cli_wrapper.py
@@ -49,7 +49,7 @@ def uninstall(args):
 
 
 def freeze(args):
-    logger.debug('Running freeze command with args: None'))
+    logger.debug('Running freeze command with args: None')
     distributions = pip2.commands.freeze.freeze()
     dist_names = list(distributions.keys())
     dist_names.sort()

--- a/pip2/commands/freeze.py
+++ b/pip2/commands/freeze.py
@@ -6,6 +6,7 @@ command line usage.
 """
 
 from pip2.compat import packaging
+from pip2.log import logger
 
 
 def freeze():
@@ -24,7 +25,11 @@ def freeze():
     :rtype: dictionary
 
     """
-    results = list(packaging.database.get_distributions(use_egg_info=True))
+    try:
+        results = list(packaging.database.get_distributions(use_egg_info=True))
+    except Exception as e:
+        logger.exception(e)
+        raise
     installed = dict()
     for dist in results:
         installed[dist.name] = dict()

--- a/pip2/commands/install.py
+++ b/pip2/commands/install.py
@@ -8,6 +8,7 @@ command line usage.
 import os
 
 from pip2.compat import packaging
+from pip2.log import logger
 
 
 def install(project_list):
@@ -36,10 +37,14 @@ def install(project_list):
     for project in project_list:
         success = False
 
-        if os.path.exists(project):
-            success = packaging.install.install_local_project(project)
-        else:
-            success = packaging.install.install(project)
+        try:
+            if os.path.exists(project):
+                success = packaging.install.install_local_project(project)
+            else:
+                success = packaging.install.install(project)
+        except Exception as e:
+            logger.exception(e)
+            raise
 
         if success:
             result['installed'].append(project)

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -7,6 +7,7 @@ command line usage.
 
 import pip2.commands.freeze
 from pip2.compat import packaging
+from pip2.log import logger
 
 
 def search(query):
@@ -38,8 +39,16 @@ def search(query):
 
     """
     results = dict()
-    client = packaging.pypi.xmlrpc.Client()
-    projects = client.search_projects(name=query, summary=query)
+    try:
+        client = packaging.pypi.xmlrpc.Client()
+    except Exception as e:
+        logger.exception(e)
+        raise
+    try:
+        projects = client.search_projects(name=query, summary=query)
+    except Exception as e:
+        logger.exception(e)
+        raise
     installed = pip2.commands.freeze.freeze()
 
     for project in projects:

--- a/pip2/commands/search.py
+++ b/pip2/commands/search.py
@@ -64,6 +64,8 @@ def search(query):
                 installed[project.name]['version']
                 results[project.name]['latest_version'] = str(release.version)
         else:
+            logger.debug('Project: {0}'.format(project.name) + ' has an ' + \
+                         'irrational version string')
             results[project.name]['summary'] = "CANNOT GET SUMMARY"
 
     return results

--- a/pip2/commands/uninstall.py
+++ b/pip2/commands/uninstall.py
@@ -6,6 +6,7 @@ command line usage.
 """
 
 from pip2.compat import packaging
+from pip2.log import logger
 
 
 def uninstall(project_list):
@@ -27,7 +28,12 @@ def uninstall(project_list):
     result = {'uninstalled': [], 'failed': []}
 
     for project in project_list:
-        if packaging.install.remove(project):
+        try:
+            success = packaging.install.remove(project)
+        except Exception as e:
+            logger.exception(e)
+            raise
+        if success:
             result['uninstalled'].append(project)
         else:
             result['failed'].append(project)

--- a/pip2/locations.py
+++ b/pip2/locations.py
@@ -1,0 +1,24 @@
+"""
+These locations will be determined by the pip2 config file, but since it currently
+does not exist values will temporarily be hard-coded in.
+"""
+
+import os
+import sys
+
+# path to user's directory where pip2 log, config, and other data are stored
+usr_dir = os.path.expanduser('~')
+# pip2 directory where pip2 specific data will be stored
+default_storage_dir = None
+# path and name of pip2 log file
+default_log_file = None
+
+if sys.platform == 'win32':
+        usr_dir = os.environ.get('APPDATA', usr_dir)
+        default_storage_dir = os.path.join(usr_dir, 'pip2')
+else:
+        default_storage_dir = os.path.join(usr_dir, '.pip2')
+if not os.path.exists(default_storage_dir):
+        os.mkdir(default_storage_dir)
+
+default_log_file = os.path.join(default_storage_dir, 'pip2.log')

--- a/pip2/log.py
+++ b/pip2/log.py
@@ -7,10 +7,10 @@ import logging
 from pip2.compat import packaging
 from pip2.locations import default_log_file
 
-logger = logging.getLogger('pip2')
+logger = logging.getLogger(__name__)
 
 def setup_logger():
-    logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+    logging.basicConfig(format='%(message)s', level=logging.INFO)
 
     fmtr = logging.Formatter(fmt='%(asctime)-6s: %(name)s - %(levelname)s: ' +
                              '%(message)s', datefmt='%Y-%m-%d %H:%M:%S')
@@ -22,4 +22,3 @@ def setup_logger():
     # good idea to capture the packaging logger's messages in the same file as
     # pip2's
     packaging.logger.addHandler(hndlr)
-

--- a/pip2/log.py
+++ b/pip2/log.py
@@ -10,10 +10,12 @@ from pip2.locations import default_log_file
 logger = logging.getLogger('pip2')
 
 def setup_logger():
-    logging.basicConfig(format='%(message)s', level=logging.INFO)
+    logging.basicConfig(format='%(message)s', level=logging.DEBUG)
 
+    fmtr = logging.Formatter(fmt='%(asctime)-6s: %(name)s - %(levelname)s: ' +
+                             '%(message)s', datefmt='%Y-%m-%d %H:%M:%S')
     hndlr = logging.FileHandler(default_log_file, mode='w')
-    hndlr.setFormatter(fmt='%(asctime)s: %(name)s: %(level)s: %(message)s')
+    hndlr.setFormatter(fmtr)
 
     logger.addHandler(hndlr)
     # since packaging/distutils2 is very heavily intertwined with pip2 its a

--- a/pip2/log.py
+++ b/pip2/log.py
@@ -1,0 +1,23 @@
+"""
+Sets up the pip2 logger for use
+"""
+
+import logging
+
+from pip2.compat import packaging
+from pip2.locations import default_log_file
+
+logger = logging.getLogger('pip2')
+
+def setup_logger():
+    logging.basicConfig(format='%(message)s', level=logging.INFO)
+
+    hndlr = logging.FileHandler(default_log_file, mode='w')
+    hndlr.setFormatter(fmt='%(asctime)s: %(name)s: %(level)s: %(message)s')
+
+    logger.addHandler(hndlr)
+    # since packaging/distutils2 is very heavily intertwined with pip2 its a
+    # good idea to capture the packaging logger's messages in the same file as
+    # pip2's
+    packaging.logger.addHandler(hndlr)
+

--- a/tests/log.py
+++ b/tests/log.py
@@ -1,0 +1,20 @@
+"""
+Adds an extra handler to the pip2 logger so that tests can be easily ran
+"""
+
+import logging
+from io import StringIO
+
+import pip2.log
+
+
+def setup_logger():
+        pip2.log.setup_logger()
+
+        test_fmtr = logging.Formatter(fmt='%(message)s')
+        test_hndlr = logging.StreamHandler(stream=StringIO())
+        test_hndlr.setLevel(logging.INFO)
+        test_hndlr.setFormatter(test_fmtr)
+        pip2.log.logger.addHandler(test_hndlr)
+
+        return test_hndlr.stream

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -4,6 +4,7 @@ from io import StringIO
 
 import pip2.cli_wrapper
 import pip2.commands.freeze
+import tests.log
 from pip2.compat import mock
 from pip2.compat import packaging
 
@@ -38,11 +39,10 @@ class TestFreezeAPI():
 
 @mock.patch.object(pip2.commands.freeze, 'freeze')
 class TestFreezeCLI():
-    originalOut = sys.stdout
 
-    #capture stdout
+    #capture pip2 CLI output
     def setup(self):
-        sys.stdout = result = StringIO()
+        result = tests.log.setup_logger()
         return result
 
     def test_basic_freeze(self, mock_func):
@@ -63,11 +63,7 @@ class TestFreezeCLI():
             # display newlines for easier comparison
             result = result.replace('\n', '\\n')
             expected = expected.replace('\n', '\\n')
-            output = ('\n\nTEST FAILED' +
-                      '\nFunction: {0}'.format(inspect.stack()[1][3]) +
-                      '\nResult  : {0}\n'.format(result) +
+            output = ('\nResult  : {0}\n'.format(result) +
                       '\nExpected: {0}'.format(expected))
-            print(output, file=sys.stderr)
+            print(output)
             raise
-        finally:
-            sys.stdout = self.originalOut

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,6 +4,7 @@ from io import StringIO
 
 import pip2.commands.freeze
 import pip2.commands.search
+import tests.log
 from pip2.compat import mock
 from pip2.compat import packaging
 
@@ -84,10 +85,9 @@ class TestSearchCLI():
     sum_len = term_width - name_len - sep_len - 1
     args = mock.Mock()
     args.project = 'pkgPlaceholder'
-    originalOut = sys.stdout
 
     def setup(self):
-        sys.stdout = result = StringIO()
+        result = tests.log.setup_logger()
         return result
 
     def test_basic_display_no_results(self, mock_search, mock_getTerminalSize):
@@ -197,20 +197,9 @@ class TestSearchCLI():
         except AssertionError:
             result = result.replace('\n', '\\n')
             expected = expected.replace('\n', '\\n')
-            # tests with non-default terminal sizes are system level, so they
-            # call multiple subtests, we want to know which specific subtest
-            # failed inside the parent
-            if self.term_width == self.default_term_width:
-                parent = 'No Parent'
-            else:
-                parent = inspect.stack()[4][3]
-            output = ('\n\nTEST FAILED' +
-                      '\nFunction  : {0}'.format(inspect.stack()[1][3]) +
-                      '\nParent    : {0}'.format(parent) +
+            output = ('\nUnit test : {0}'.format(inspect.stack()[1][3]) +
                       '\nTerm width: {0}'.format(self.term_width) +
                       '\nResult    : \n{0}\n'.format(result) +
                       '\nExpected  : \n{0}'.format(expected))
-            print(output, file=sys.stderr)
+            print(output)
             raise
-        finally:
-            sys.stdout = self.originalOut


### PR DESCRIPTION
Fixes: #55

Added a standard logger to pip2. The logger is located in APPDATA for Windows and in the user's home directory for Mac and Linux.

Added files: 
- pip2\locations.py
  Has default config parameters for pip2.
- pip2\log.py
  Sets up the pip2 logger
- tests\log.py
  Adds onto the pip2 logger so that tests can be easily ran using logged output instead of sys.stdout.
