### PR TITLE
Yank Python 3.3 Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ development. Pip2 currently provides minimal install, uninstall, search and
 freeze commands that use distutils2/packaging under the hood.
 
 See the `pip2 contribution instructions`_ for details on setting up a
-development environment and installing pip2. Note that only Python 3.2 and 3.3
-(currently in alpha) are supported at this time.
+development environment and installing pip2. Note that only Python 3.2 is
+supported at this time.
 
 .. _distutils2/packaging: http://pypi.python.org/pypi/Distutils2
 .. _pip2 contribution instructions: http://pip2.readthedocs.org/en/latest/dev/contributing.html

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -9,16 +9,14 @@ Contributing with Code
 Supported Python Versions
 -------------------------
 
-Pip2 currently only supports Python 3.2 and 3.3 (scheduled for release in
-August 2012), but there are plans to support versions of Python back to
-2.6-ish.
+Pip2 currently only supports Python 3.2.
 
 Prerequisites
 -------------
 
 The following tools are required:
 
-- Python 3.2 or 3.3 (preferably both)
+- Python 3.2
 - Git
 - pip and virtualenv
 
@@ -42,19 +40,19 @@ fork::
 Installation
 ------------
 
-Create and activate a virtualenv for pip2 development. For example, if you are
-developing with Python 3.2::
+Create and activate a virtualenv for pip2 development. For example::
 
-    $ virtualenv --python=python3.2 pip2-dev-py3.2
-    $ source pip2-dev-py3.2/bin/activate
+    $ virtualenv --python=python3.2 pip2-dev
+    $ source pip2-dev/bin/activate
 
-For versions of Python prior to 3.3, pip2 depends on distutils2 which is often
-`broken`_ and/or outdated on PyPI. For now, just use pip to install from the
-python3 branch of the distutils2 repository::
+Pip2 depends on Distutils2 which currently doesn't have a version for Python 3
+on PyPI (see `issue #45`_). For now, just use pip to install from the
+``python3`` branch of the `Distutils2 repository`_::
 
     $ pip install http://hg.python.org/distutils2/archive/python3.tar.bz2
 
-.. _broken: http://github.com/osupython/pip2/issues/45
+.. _issue #45: http://github.com/osupython/pip2/issues/45
+.. _Distutils2 repository: http://hg.python.org/distutils2/
 
 Install pip2::
 

--- a/pip2/compat.py
+++ b/pip2/compat.py
@@ -8,11 +8,14 @@ try:
     import distutils2.install
     import distutils2.pypi
 except ImportError:
-    # Available in the standard library in Python 3.3+
-    import packaging
-    import packaging.database
-    import packaging.install
-    import packaging.pypi
+    # Initially planned for the Python 3.3 standard library, but yanked out
+    # because it wasn't ready. This is left here in case it goes back in for
+    # Python 3.4.
+    #import packaging
+    #import packaging.database
+    #import packaging.install
+    #import packaging.pypi
+    raise
 
 # Try importing the non-stdlib version of mock first to allow newer versions to
 # override older functionality in the standard library.

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,11 @@ version = '0.0.1.dev1'
 
 install_requires = []
 
-if sys.version_info < (3, 3):
-    # Distutils2 is required for Python versions prior to 3.3, but there is
-    # currently no Python 3 version on PyPI (see GitHub issue 45). For now,
-    # only depend on distutils2 for Python 2; it needs to be installed manually
-    # for Python 3 (prior to 3.3).
-    if sys.version_info < (3,):
-        install_requires.append('distutils2')
+# There is currently no Python 3 version of Distutils2 on PyPI (see GitHub
+# issue 45). For now, only depend on distutils2 for Python 2; it needs to be
+# installed manually for Python 3.
+if sys.version_info < (3,):
+    install_requires.append('distutils2')
 
 
 setup(name="pip2",
@@ -30,7 +28,6 @@ setup(name="pip2",
           'Topic :: Software Development :: Build Tools',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.2',
-          'Programming Language :: Python :: 3.3',
       ],
       keywords='pip packaging distutils2 easy_install setuptools',
       author='OSUPython Senior Design Team',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py32,py33,py33-3rd-party-libs,rtfd
+envlist = py32,rtfd
 
 [testenv:py32]
 commands =
@@ -9,21 +9,13 @@ deps =
     mock
     http://hg.python.org/distutils2/archive/python3.tar.bz2
 
-[testenv:py33]
-basepython = python3.3
-commands =
-    nosetests {posargs}
-deps =
-    nose
-
-[testenv:py33-3rd-party-libs]
-basepython = python3.3
-commands =
-    nosetests {posargs}
-deps =
-    nose
-    mock
-    http://hg.python.org/distutils2/archive/python3.tar.bz2
+# Python 3.3 is not supported yet
+#[testenv:py33]
+#basepython = python3.3
+#commands =
+#    nosetests {posargs}
+#deps =
+#    http://hg.python.org/distutils2/archive/python3.tar.bz2
 
 # Verify the documentation will build for readthedocs.org
 [testenv:rtfd]


### PR DESCRIPTION
As you probably know, `packaging` is no longer scheduled for Python 3.3 because it wasn't ready yet. Hopefully it will make it back in for Python 3.4, but for now I'm removing references to the `packaging` in the standard library. Also, I was unable to get the Python 3.3 alpha working last time I tried because of the new built-in pyvenv (I believe virtualenv no longer worked with the alpha and pip didn't work with the built-in pyvenv). I removed Python 3.3 support until it's officially released and pip2 works with it again.
